### PR TITLE
Add microsecond timer driver

### DIFF
--- a/imu/imu.h
+++ b/imu/imu.h
@@ -24,6 +24,7 @@
 #ifndef IMU_H
 #define IMU_H
 
+#include <stdbool.h>
 #include "stm32h7xx_hal.h"
 
 #ifdef __cplusplus

--- a/timer/timer.c
+++ b/timer/timer.c
@@ -1,23 +1,20 @@
-/*******************************************************************************
-*
-* FILE:
-* 		timer.c
-*
-* DESCRIPTION:
-* 		Timer delays and tick
-*
-* COPYRIGHT:                                                                   
-*       Copyright (c) 2025 Sun Devil Rocketry.                                 
-*       All rights reserved.                                                   
-*                                                                              
-*       This software is licensed under terms that can be found in the LICENSE 
-*       file in the root directory of this software component.                 
-*       If no LICENSE file comes with this software, it is covered under the   
-*       BSD-3-Clause.                                                          
-*                                                                              
-*       https://opensource.org/license/bsd-3-clause          
-*
-*******************************************************************************/
+
+/**
+ * @file timer.c
+ * 
+ * @brief Timer delays and tick
+ * 
+ * @copyright
+ *       Copyright (c) 2025 Sun Devil Rocketry.                                 
+ *       All rights reserved.                                                   
+ *                                                                              
+ *       This software is licensed under terms that can be found in the LICENSE 
+ *       file in the root directory of this software component.                 
+ *       If no LICENSE file comes with this software, it is covered under the   
+ *       BSD-3-Clause.                                                          
+ *                                                                              
+ *       https://opensource.org/license/bsd-3-clause        
+ */
 
 /*------------------------------------------------------------------------------
  Standard Includes                                                                     
@@ -51,14 +48,14 @@ uint8_t micro_tim_wraparounds = 0;
 ------------------------------------------------------------------------------*/
 
 /**
- * @brief Getter for microsecond tick.
+ * @brief Getter for microsecond tick
  * 
  * Returns the microsecond tick as a sum of the number of wraparounds times the period plus the
  * current value in the counter register. This mitigates the fact that the timer itself 
  * wraps around approximately every 71.5 minutes if configured to count all the way to the 
  * uint32 max. This gives us over a million seconds or over 300 hours, which will probably be enough...
  * 
- * @return Microsecond tick.
+ * @return Microsecond tick
  */
 uint64_t get_us_tick
     (
@@ -72,7 +69,7 @@ return tick;
 
 
 /**
- * @brief Minimum delay in miliseconds.
+ * @brief Minimum delay in miliseconds
  */
 void delay_ms
     (
@@ -85,7 +82,7 @@ HAL_Delay(delay);
 
 
 /**
- * @brief Minimum delay in microseconds.
+ * @brief Minimum delay in microseconds
  */
 void delay_us
     (
@@ -101,7 +98,7 @@ while ( get_us_tick() < target ) {}
 
 
 /**
- * @brief Upon timer overflow, increments the wraparound counter.
+ * @brief Upon timer overflow, increments the wraparound counter
  */
 void micro_tim_IT_handler
     (

--- a/timer/timer.c
+++ b/timer/timer.c
@@ -30,11 +30,15 @@
 #include "main.h"
 #include "stm32h7xx_hal_tim.h"
 #include "sdr_pin_defines_A0002.h"
+#include "timer.h"
 
 
 /*------------------------------------------------------------------------------
  Global Variables  
 ------------------------------------------------------------------------------*/
+
+/* Increments every time the timer wraps around */
+uint8_t micro_tim_wraparounds = 0;
 
 
 /*------------------------------------------------------------------------------
@@ -46,36 +50,30 @@
  API Functions 
 ------------------------------------------------------------------------------*/
 
-/*******************************************************************************
-*                                                                              *
-* PROCEDURE:                                                                   *
-* 		get_us_tick                                                            *
-*                                                                              *
-* DESCRIPTION:                                                                 *
-* 		Getter for value in microsecond timer register                         *
-* NOTE:                                                                        *
-* 		This is a 32-bit timer that will wrap around after reaching            *
-* 		the uint_32 max in approximately 71.5 minutes                          *
-*                                                                              *
-*******************************************************************************/
-uint32_t get_us_tick
+/**
+ * @brief Getter for microsecond tick.
+ * 
+ * Returns the microsecond tick as a sum of the number of wraparounds times the period plus the
+ * current value in the counter register. This mitigates the fact that the timer itself 
+ * wraps around approximately every 71.5 minutes if configured to count all the way to the 
+ * uint32 max. This gives us over a million seconds or over 300 hours, which will probably be enough...
+ * 
+ * @return Microsecond tick.
+ */
+uint64_t get_us_tick
     (
     void
     )
 {
-return __HAL_TIM_GET_COUNTER(&MICRO_TIM);
+uint64_t tick = micro_tim_wraparounds * MICRO_TIM.Init.Period + __HAL_TIM_GET_COUNTER(&MICRO_TIM);
+return tick;
+
 } /* get_us_tick */
 
 
-/*******************************************************************************
-*                                                                              *
-* PROCEDURE:                                                                   * 
-* 		delay_ms                                                               *
-*                                                                              *
-* DESCRIPTION:                                                                 * 
-* 		Minimum delay in miliseconds                                           *
-*                                                                              *
-*******************************************************************************/
+/**
+ * @brief Minimum delay in miliseconds.
+ */
 void delay_ms
     (
     uint32_t delay
@@ -86,30 +84,33 @@ HAL_Delay(delay);
 } /* delay_ms */
 
 
-/*******************************************************************************
-*                                                                              *
-* PROCEDURE:                                                                   *
-* 		delay_us                                                               *
-*                                                                              *
-* DESCRIPTION:                                                                 *
-* 		Minimum delay in microseconds                                          *
-*                                                                              *
-*******************************************************************************/
+/**
+ * @brief Minimum delay in microseconds.
+ */
 void delay_us
     (
     uint32_t delay
     )
 {
-uint32_t start = get_us_tick();
-uint32_t target = start + delay;
-if (target < start) /* timer will wrap around */
-    {
-    while ( get_us_tick() <= UINT32_MAX ) {}
-    }
+uint64_t start = get_us_tick();
+uint64_t target = start + delay;
 
 while ( get_us_tick() < target ) {}
 
 } /* delay_us */
+
+
+/**
+ * @brief Upon timer overflow, increments the wraparound counter.
+ */
+void micro_tim_IT_handler
+    (
+    void
+    )
+{
+micro_tim_wraparounds++;
+
+} /* micro_tim_IT_handler */
 
 /*******************************************************************************
 * END OF FILE                                                                  * 

--- a/timer/timer.c
+++ b/timer/timer.c
@@ -1,0 +1,116 @@
+/*******************************************************************************
+*
+* FILE:
+* 		timer.c
+*
+* DESCRIPTION:
+* 		Timer delays and tick
+*
+* COPYRIGHT:                                                                   
+*       Copyright (c) 2025 Sun Devil Rocketry.                                 
+*       All rights reserved.                                                   
+*                                                                              
+*       This software is licensed under terms that can be found in the LICENSE 
+*       file in the root directory of this software component.                 
+*       If no LICENSE file comes with this software, it is covered under the   
+*       BSD-3-Clause.                                                          
+*                                                                              
+*       https://opensource.org/license/bsd-3-clause          
+*
+*******************************************************************************/
+
+/*------------------------------------------------------------------------------
+ Standard Includes                                                                     
+------------------------------------------------------------------------------*/
+
+
+/*------------------------------------------------------------------------------
+ Project Includes                                                                     
+------------------------------------------------------------------------------*/
+#include "main.h"
+#include "stm32h7xx_hal_tim.h"
+#include "sdr_pin_defines_A0002.h"
+
+
+/*------------------------------------------------------------------------------
+ Global Variables  
+------------------------------------------------------------------------------*/
+
+
+/*------------------------------------------------------------------------------
+ Internal function prototypes 
+------------------------------------------------------------------------------*/
+
+
+/*------------------------------------------------------------------------------
+ API Functions 
+------------------------------------------------------------------------------*/
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   *
+* 		get_us_tick                                                            *
+*                                                                              *
+* DESCRIPTION:                                                                 *
+* 		Getter for value in microsecond timer register                         *
+* NOTE:                                                                        *
+* 		This is a 32-bit timer that will wrap around after reaching            *
+* 		the uint_32 max in approximately 71.5 minutes                          *
+*                                                                              *
+*******************************************************************************/
+uint32_t get_us_tick
+    (
+    void
+    )
+{
+return __HAL_TIM_GET_COUNTER(&MICRO_TIM);
+} /* get_us_tick */
+
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   * 
+* 		delay_ms                                                               *
+*                                                                              *
+* DESCRIPTION:                                                                 * 
+* 		Minimum delay in miliseconds                                           *
+*                                                                              *
+*******************************************************************************/
+void delay_ms
+    (
+    uint32_t delay
+    )
+{
+HAL_Delay(delay);
+
+} /* delay_ms */
+
+
+/*******************************************************************************
+*                                                                              *
+* PROCEDURE:                                                                   *
+* 		delay_us                                                               *
+*                                                                              *
+* DESCRIPTION:                                                                 *
+* 		Minimum delay in microseconds                                          *
+*                                                                              *
+*******************************************************************************/
+void delay_us
+    (
+    uint32_t delay
+    )
+{
+uint32_t start = get_us_tick();
+uint32_t target = start + delay;
+if (target < start) /* timer will wrap around */
+    {
+    while ( get_us_tick() <= UINT32_MAX ) {}
+    }
+
+while ( get_us_tick() < target ) {}
+
+} /* delay_us */
+
+/*******************************************************************************
+* END OF FILE                                                                  * 
+*******************************************************************************/

--- a/timer/timer.c
+++ b/timer/timer.c
@@ -1,4 +1,3 @@
-
 /**
  * @file timer.c
  * 
@@ -70,6 +69,8 @@ return tick;
 
 /**
  * @brief Minimum delay in miliseconds
+ * 
+ * @param delay Delay in miliseconds
  */
 void delay_ms
     (
@@ -83,6 +84,8 @@ HAL_Delay(delay);
 
 /**
  * @brief Minimum delay in microseconds
+ * 
+ * @param delay Delay in microseconds
  */
 void delay_us
     (

--- a/timer/timer.h
+++ b/timer/timer.h
@@ -1,23 +1,19 @@
-/*******************************************************************************
-*
-* FILE:
-* 		timer.h
-*
-* DESCRIPTION:
-* 		Timer delays and tick
-*
-* COPYRIGHT:                                                                   
-*       Copyright (c) 2025 Sun Devil Rocketry.                                 
-*       All rights reserved.                                                   
-*                                                                              
-*       This software is licensed under terms that can be found in the LICENSE 
-*       file in the root directory of this software component.                 
-*       If no LICENSE file comes with this software, it is covered under the   
-*       BSD-3-Clause.                                                          
-*                                                                              
-*       https://opensource.org/license/bsd-3-clause          
-*
-*******************************************************************************/
+/**
+ * @file timer.h
+ * 
+ * @brief Timer delays and tick
+ * 
+ * @copyright
+ *       Copyright (c) 2025 Sun Devil Rocketry.                                 
+ *       All rights reserved.                                                   
+ *                                                                              
+ *       This software is licensed under terms that can be found in the LICENSE 
+ *       file in the root directory of this software component.                 
+ *       If no LICENSE file comes with this software, it is covered under the   
+ *       BSD-3-Clause.                                                          
+ *                                                                              
+ *       https://opensource.org/license/bsd-3-clause        
+ */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef TIMER_H 

--- a/timer/timer.h
+++ b/timer/timer.h
@@ -1,0 +1,57 @@
+/*******************************************************************************
+*
+* FILE:
+* 		timer.h
+*
+* DESCRIPTION:
+* 		Timer delays and tick
+*
+* COPYRIGHT:                                                                   
+*       Copyright (c) 2025 Sun Devil Rocketry.                                 
+*       All rights reserved.                                                   
+*                                                                              
+*       This software is licensed under terms that can be found in the LICENSE 
+*       file in the root directory of this software component.                 
+*       If no LICENSE file comes with this software, it is covered under the   
+*       BSD-3-Clause.                                                          
+*                                                                              
+*       https://opensource.org/license/bsd-3-clause          
+*
+*******************************************************************************/
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef TIMER_H 
+#define TIMER_H 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*------------------------------------------------------------------------------
+ Function Prototypes 
+------------------------------------------------------------------------------*/
+
+uint32_t get_us_tick
+    (
+    void
+    );
+
+void delay_ms
+    (
+    uint32_t delay
+    );
+
+void delay_us
+    (
+    uint32_t delay
+    );
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* TIMER_H */
+
+/*******************************************************************************
+* END OF FILE                                                                  * 
+*******************************************************************************/

--- a/timer/timer.h
+++ b/timer/timer.h
@@ -32,7 +32,7 @@ extern "C" {
  Function Prototypes 
 ------------------------------------------------------------------------------*/
 
-uint32_t get_us_tick
+uint64_t get_us_tick
     (
     void
     );
@@ -45,6 +45,11 @@ void delay_ms
 void delay_us
     (
     uint32_t delay
+    );
+
+void micro_tim_IT_handler
+    (
+    void
     );
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description
Add a microsecond timer based on htim5 and a 64-bit tick. This also includes a microsecond delay function and moves the `HAL_Delay()` wrapper for a ms delay.

### Issue Link
Part of [FCF #102](https://github.com/SunDevilRocketry/mod/issues/102)

Parent: [FCF #242](https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/242)

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code