### PR TITLE
fix: lora preset download bug

### DIFF
--- a/lora/lora.c
+++ b/lora/lora.c
@@ -314,7 +314,7 @@ switch (subcommand_code)
     case LORA_PRESET_DOWNLOAD:
         {
         /* tx straight from buffer (usb transmit does not modify the buffer) */
-        if( usb_transmit( lora_preset_buf, sizeof( LORA_PRESET ), 10 * HAL_DEFAULT_TIMEOUT ) )
+        if( usb_transmit( lora_preset_buf, sizeof( LORA_PRESET ), 10 * HAL_DEFAULT_TIMEOUT ) == USB_OK )
             {
             return LORA_OK;
             }


### PR DESCRIPTION
## Description
Fixes the fail-fast error thrown from lora preset download.

bruh i hate that this was it lmao. USB_OK is 0, so that if statement was going down the else branch when it returned USB_OK.

### Issue Link
Closes https://github.com/SunDevilRocketry/Flight-Computer-Firmware/issues/250.

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified (link the test changes as a child PR)
- [ ] Integration test performed

Tested manually.

### Other
N/A

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code