### PR TITLE
Add some delay to avoid overloading the PTY buffer

### DIFF
--- a/flash/flash.c
+++ b/flash/flash.c
@@ -293,10 +293,8 @@ switch ( opcode )
 			/* Read from next address */
 			(pflash_handle->address) += sizeof( buffer ) ;
 
-            #ifdef EMULATOR
-            #ifdef __linux__
+            #if defined( EMULATOR ) && defined( __linux__ )
             HAL_Delay(15); /* add a small delay -- SDEC reads slower than we tx */
-            #endif
             #endif
 			}
 

--- a/flash/flash.c
+++ b/flash/flash.c
@@ -292,6 +292,12 @@ switch ( opcode )
 
 			/* Read from next address */
 			(pflash_handle->address) += sizeof( buffer ) ;
+
+            #ifdef EMULATOR
+            #ifdef __linux__
+            HAL_Delay(15); /* add a small delay -- SDEC reads slower than we tx */
+            #endif
+            #endif
 			}
 
 		return FLASH_OK;


### PR DESCRIPTION
## Description
Fixes an issue on the linux emulator where the SDEC buffer would overflow and we'd lose data.

### Issue Link
Parent: https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/274

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code