### PR TITLE
Change I2C sensor flags to true atomics

### DIFF
--- a/baro/baro.c
+++ b/baro/baro.c
@@ -26,7 +26,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <math.h>
-
+#include <stdatomic.h>
 
 /*------------------------------------------------------------------------------
  Project Includes                                                                     
@@ -34,7 +34,6 @@
 #include "main.h"
 #include "sdr_pin_defines_A0002.h"
 #include "baro.h"
-
 
 /*------------------------------------------------------------------------------
 Global Variables  
@@ -49,7 +48,7 @@ static BARO_CAL_DATA baro_cal_data;
 uint8_t baro_raw_buffer[6];
 float baro_pres_proc = NAN;
 float baro_temp_proc = NAN;
-static bool baro_data_ready = false;
+static atomic_bool baro_data_ready = false;
 
 
 /*------------------------------------------------------------------------------

--- a/imu/imu.c
+++ b/imu/imu.c
@@ -24,6 +24,7 @@
  Standard Includes                                                              
 ------------------------------------------------------------------------------*/
 #include <string.h>
+#include <stdatomic.h>
 
 /*------------------------------------------------------------------------------
  Project Includes                                                               
@@ -52,10 +53,10 @@
 #if defined( A0002_REV2 )
 uint8_t imu_raw_buffer[12];
 IMU_RAW imu_raw_processed;
-static bool imu_data_ready;
+static atomic_bool imu_data_ready;
 
 uint8_t mag_raw_buffer[8];
-static bool mag_data_ready;
+static atomic_bool mag_data_ready;
 #endif
 
 MAG_TRIM mag_trim;


### PR DESCRIPTION
## Description
Currently, we use boolean flags to signal when sensor data is ready. These are not thread-safe, and a read->modify->write operation can be interrupted, possibly resulting in undefined behavior in very **VERY** rare cases. This PR eliminates that possibility by using the stdatomic atomic_bool.

Tagging @butchhartman and @NArmistead both on this one since I think @butchhartman might have more experience with thread safety.

### Issue Link
Parent: https://github.com/SunDevilRocketry/Flight-Computer-Firmware/pull/280

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified
- [X] Integration test performed

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code