### PR TITLE
Enable GPS module for rev 3

### DIFF
--- a/gps/gps.c
+++ b/gps/gps.c
@@ -38,6 +38,8 @@
 	#include "sdr_pin_defines_A0005.h"
 #elif defined( FLIGHT_COMPUTER_LITE )
 	#include "sdr_pin_defines_A0007.h"
+#elif defined( A0010 )
+    #include "sdr_pin_defines_A0010.h"
 #endif
 
 


### PR DESCRIPTION
## Description
Adds the rev 3 pindefs to rev 3 GPS. Should be no further development required on GPS until initial integration.

### Issue Link
Closes #38.

### Testing
- [x] Passes existing unit tests
- [ ] Unit tests modified
- [ ] Integration test performed

Should pass existing GPS unit tests. Rev 3's project side does not yet fulfill the contract requirements for integration, but the driver is ready at least.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code