### PR TITLE
Baro: Initial R3 Driver Implementation

### DIFF
--- a/baro/baro.c
+++ b/baro/baro.c
@@ -950,7 +950,7 @@ else
 *                                                                              *
 * DESCRIPTION:                                                                 * 
 * 		ISR for baro data reception. Heavy ISR.	Consider moving processing to  *
-*		baro_get_it.								                           *
+*		baro_get_IT.								                           *
 *                                                                              *
 *******************************************************************************/
 BARO_STATUS baro_IT_handler
@@ -1003,13 +1003,13 @@ return baro_status;
 /*******************************************************************************
 *                                                                              *
 * PROCEDURE:                                                                   * 
-* 		baro_get_it                   		                               	   *
+* 		baro_get_IT                   		                               	   *
 *                                                                              *
 * DESCRIPTION:                                                                 * 
 * 		Getter function for IT baro data.				                       *
 *                                                                              *
 *******************************************************************************/
-BARO_STATUS baro_get_it
+BARO_STATUS baro_get_IT
 	(
 	float* pres_ptr, /* o: pressure */
 	float* temp_ptr  /* o: temperature */
@@ -1024,7 +1024,7 @@ if( !baro_data_ready )
 *temp_ptr = baro_temp_proc;
 
 return BARO_OK;
-} /* baro_get_it */
+} /* baro_get_IT */
 
 
 /*******************************************************************************

--- a/baro/baro.c
+++ b/baro/baro.c
@@ -1,27 +1,27 @@
 /*******************************************************************************
 *
-* FILE: 
+* FILE:
 * 		baro.c
 *
-* DESCRIPTION: 
+* DESCRIPTION:
 * 		Contains API functions for the barometric pressure sensor
 *
-* COPYRIGHT:                                                                   
-*       Copyright (c) 2025 Sun Devil Rocketry.                                 
-*       All rights reserved.                                                   
-*                                                                              
-*       This software is licensed under terms that can be found in the LICENSE 
-*       file in the root directory of this software component.                 
-*       If no LICENSE file comes with this software, it is covered under the   
-*       BSD-3-Clause.                                                          
-*                                                                              
-*       https://opensource.org/license/bsd-3-clause          
+* COPYRIGHT:
+*       Copyright (c) 2025 Sun Devil Rocketry.
+*       All rights reserved.
+*
+*       This software is licensed under terms that can be found in the LICENSE
+*       file in the root directory of this software component.
+*       If no LICENSE file comes with this software, it is covered under the
+*       BSD-3-Clause.
+*
+*       https://opensource.org/license/bsd-3-clause
 *
 *******************************************************************************/
 
 
 /*------------------------------------------------------------------------------
- Standard Includes                                                                     
+ Standard Includes
 ------------------------------------------------------------------------------*/
 #include <stdbool.h>
 #include <string.h>
@@ -29,14 +29,14 @@
 #include <stdatomic.h>
 
 /*------------------------------------------------------------------------------
- Project Includes                                                                     
+ Project Includes
 ------------------------------------------------------------------------------*/
 #include "main.h"
 #include "sdr_pin_defines_A0002.h"
 #include "baro.h"
 
 /*------------------------------------------------------------------------------
-Global Variables  
+Global Variables
 ------------------------------------------------------------------------------*/
 
 /* Current Baro Sensor configuration */
@@ -52,7 +52,7 @@ static atomic_bool baro_data_ready = false;
 
 
 /*------------------------------------------------------------------------------
- Internal function prototypes 
+ Internal function prototypes
 ------------------------------------------------------------------------------*/
 
 /* Converts two bytes to uint16_t format */
@@ -85,6 +85,12 @@ static BARO_STATUS write_reg
 	uint8_t  data      /* In: Register contents           */
 	);
 
+/* Configure/intialize the barometric pressure sensor */
+static BARO_STATUS baro_config
+		(
+		BARO_CONFIG* config_ptr
+		);
+
 /* Load the compensation data from the baro sensor */
 static BARO_STATUS load_cal_data
 	(
@@ -98,7 +104,7 @@ static float temp_compensate
 	);
 
 /* Apply the compensation formula to raw pressure readouts */
-static float press_compensate 
+static float press_compensate
 	(
 	uint32_t raw_readout
 	);
@@ -117,16 +123,16 @@ static BARO_STATUS baro_flush_fifo
 
 
 /*------------------------------------------------------------------------------
- API Functions 
+ API Functions
 ------------------------------------------------------------------------------*/
 
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 *       baro_init                                                              *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		Intialize the barometric pressure sensor                               *
 *                                                                              *
 *******************************************************************************/
@@ -136,7 +142,7 @@ BARO_STATUS baro_init
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 BARO_STATUS       baro_status;    /* Status code from Baro API calls   */
 uint8_t           baro_device_id; /* Baro device id                    */
@@ -145,7 +151,7 @@ float             init_temp;      /* Temperature read after init       */
 
 
 /*------------------------------------------------------------------------------
- Initializations 
+ Initializations
 ------------------------------------------------------------------------------*/
 baro_status    = BARO_OK;
 baro_device_id = 0;
@@ -154,7 +160,7 @@ init_temp      = 0;
 
 
 /*------------------------------------------------------------------------------
- API Function Implementation 
+ API Function Implementation
 ------------------------------------------------------------------------------*/
 
 /* Disable IRQ */
@@ -181,8 +187,8 @@ if ( baro_status != BARO_OK )
 HAL_Delay( 10 );
 
 /* Check the Baro error register */
-baro_status = read_regs( BARO_REG_ERR_REG      , 
-                         sizeof( baro_err_reg ), 
+baro_status = read_regs( BARO_REG_ERR_REG      ,
+                         sizeof( baro_err_reg ),
 						 &baro_err_reg );
 if ( baro_status != BARO_OK )
 	{
@@ -210,7 +216,7 @@ if ( baro_status != BARO_OK )
 /* Initialize the compensation temperature */
 baro_status = baro_get_temp( &init_temp );
 if ( baro_status != BARO_OK )
-	{ 
+	{
 	return baro_status;
 	}
 
@@ -229,20 +235,20 @@ return baro_status;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 *       baro_config                                                            *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		Configure the barometric pressure sensor                               *
 *                                                                              *
 *******************************************************************************/
-BARO_STATUS baro_config
+static BARO_STATUS baro_config
 	(
 	BARO_CONFIG* config_ptr
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 BARO_STATUS   baro_status; /* Baro API call return codes                  */
 uint8_t       pwr_ctrl;    /* Contents of PWR_CTRL register               */
@@ -252,7 +258,7 @@ uint8_t       iir;         /* Contents of CONFIG register (IIR Filter)    */
 
 
 /*------------------------------------------------------------------------------
- Initializations 
+ Initializations
 ------------------------------------------------------------------------------*/
 baro_status = BARO_OK;
 pwr_ctrl    = 0;
@@ -262,7 +268,7 @@ iir         = 0;
 
 
 /*------------------------------------------------------------------------------
- Extract Baro settings from config struct  
+ Extract Baro settings from config struct
 ------------------------------------------------------------------------------*/
 
 /* Set register contents */
@@ -283,7 +289,7 @@ baro_configuration.IIR_setting       = config_ptr -> IIR_setting;
 
 
 /*------------------------------------------------------------------------------
- API function implementation 
+ API function implementation
 ------------------------------------------------------------------------------*/
 
 /* Write to the PWR_CTRL register -> Operating mode and enable sensors */
@@ -322,32 +328,32 @@ return BARO_OK;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 * 		baro_get_device_id                                                     *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		Gets the device ID of the barometric pressure sensor, primarily used   *
 *       to verify that the sensor can be accessed by the MCU                   *
 *                                                                              *
 *******************************************************************************/
 BARO_STATUS baro_get_device_id
 	(
-   	uint8_t* baro_id_ptr /* Out: Baro device id */ 
+   	uint8_t* baro_id_ptr /* Out: Baro device id */
 	)
 {
 /*------------------------------------------------------------------------------
- Local Variables 
+ Local Variables
 ------------------------------------------------------------------------------*/
 BARO_STATUS baro_status; /* Status codes returned from baro API calls */
 
 
 /*------------------------------------------------------------------------------
- API Function implementation 
+ API Function implementation
 ------------------------------------------------------------------------------*/
 
 /* Read baro register with I2C */
-baro_status = read_regs( BARO_REG_CHIP_ID, 
-                         sizeof( uint8_t ), 
+baro_status = read_regs( BARO_REG_CHIP_ID,
+                         sizeof( uint8_t ),
 						 baro_id_ptr );
 return baro_status;
 } /* baro_get_device_id */
@@ -355,10 +361,10 @@ return baro_status;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 * 		baro_get_pressure                                                      *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		retrieves a pressure reading from the sensor                           *
 *                                                                              *
 *******************************************************************************/
@@ -368,7 +374,7 @@ BARO_STATUS baro_get_pressure
 	)
 {
 /*------------------------------------------------------------------------------
-Local variables 
+Local variables
 ------------------------------------------------------------------------------*/
 uint8_t     pressure_bytes[3]; /* Pressure raw readout bytes, LSB first   */
 uint32_t    raw_pressure;      /* Pressure raw readout in uint32_t format */
@@ -386,12 +392,12 @@ memset( &pressure_bytes[0], 0, sizeof( pressure_bytes ) );
 
 
 /*------------------------------------------------------------------------------
-API function implementation 
+API function implementation
 ------------------------------------------------------------------------------*/
 
 /* Read 3 consecutive pressure data registers */
-baro_status = read_regs( BARO_REG_PRESS_DATA, 
-                         sizeof( pressure_bytes ), 
+baro_status = read_regs( BARO_REG_PRESS_DATA,
+                         sizeof( pressure_bytes ),
 						 &pressure_bytes[0] );
 if ( baro_status != BARO_OK )
 	{
@@ -415,20 +421,20 @@ return BARO_OK;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 * 		baro_get_temp                                                          *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		retrieves a temperature reading from the sensor                        *
 *                                                                              *
 *******************************************************************************/
 BARO_STATUS baro_get_temp
 	(
-    float* temp_ptr 
+    float* temp_ptr
 	)
 {
 /*------------------------------------------------------------------------------
-Local variables 
+Local variables
 ------------------------------------------------------------------------------*/
 uint8_t     temp_bytes[3]; /* Raw temperature readout bytes, LSB first */
 uint32_t    raw_temp;      /* Raw temperature readout in uint32_t format */
@@ -444,12 +450,12 @@ memset( &temp_bytes[0], 0, sizeof( temp_bytes ) );
 
 
 /*------------------------------------------------------------------------------
-API function implementation 
+API function implementation
 ------------------------------------------------------------------------------*/
 
 /* Read 3 consecutive temperature data registers */
-baro_status = read_regs( BARO_REG_TEMP_DATA  , 
-                         sizeof( temp_bytes ), 
+baro_status = read_regs( BARO_REG_TEMP_DATA  ,
+                         sizeof( temp_bytes ),
 						 &temp_bytes[0] );
 if ( baro_status != BARO_OK )
 	{
@@ -459,7 +465,7 @@ if ( baro_status != BARO_OK )
 /* Combine all bytes value to 24 bit value */
 raw_temp = ( ( (uint32_t) temp_bytes[2] << 16 ) |
              ( (uint32_t) temp_bytes[1] <<  8 ) |
-			 ( (uint32_t) temp_bytes[0]       ) ); 
+			 ( (uint32_t) temp_bytes[0]       ) );
 
 /* Adjust using calibration data */
 *temp_ptr = temp_compensate( raw_temp );
@@ -471,10 +477,10 @@ return BARO_OK;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 * 		baro_get_altitude                                                      *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		gets the altitude of the rocket from the sensor readouts               *
 *                                                                              *
 *******************************************************************************/
@@ -488,7 +494,7 @@ return BARO_OK;
 
 
 /*------------------------------------------------------------------------------
- Internal procedures 
+ Internal procedures
 ------------------------------------------------------------------------------*/
 
 
@@ -548,9 +554,9 @@ static BARO_STATUS read_regs
 	uint8_t  num_regs, /* In:  Number of registers to read */
 	uint8_t* pData     /* Out: Register contents           */
 	)
-{   
+{
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 HAL_StatusTypeDef hal_status;  /* HAL API Return codes */
 uint32_t          i2c_timeout; /* I2C read timeout     */
@@ -564,7 +570,7 @@ i2c_timeout = BARO_DEFAULT_TIMEOUT*num_regs;
 
 
 /*------------------------------------------------------------------------------
- Implementation 
+ Implementation
 ------------------------------------------------------------------------------*/
 
 /* Read I2C register*/
@@ -573,7 +579,7 @@ hal_status = HAL_I2C_Mem_Read( &( BARO_I2C )       ,
 				               reg_addr            ,
 				               I2C_MEMADD_SIZE_8BIT,
 				               pData               ,
-				               num_regs            , 
+				               num_regs            ,
 				               i2c_timeout );
 if ( hal_status != HAL_OK )
 	{
@@ -589,10 +595,10 @@ else
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 *       write_reg                                                              *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 *       Write to one of the baro's registers at a specified address            *
 *                                                                              *
 *******************************************************************************/
@@ -601,15 +607,15 @@ static BARO_STATUS write_reg
 	uint8_t  reg_addr, /* In: Register address            */
 	uint8_t  data      /* In: Register contents           */
 	)
-{   
+{
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 HAL_StatusTypeDef hal_status; /* HAL API Return codes */
 
 
 /*------------------------------------------------------------------------------
- Implementation 
+ Implementation
 ------------------------------------------------------------------------------*/
 
 /* Write to register with I2C */
@@ -618,7 +624,7 @@ hal_status = HAL_I2C_Mem_Write( &( BARO_I2C )       ,
 				                reg_addr            ,
 				                I2C_MEMADD_SIZE_8BIT,
 				                &data               ,
-				                sizeof( uint8_t )   , 
+				                sizeof( uint8_t )   ,
 				                BARO_DEFAULT_TIMEOUT );
 if ( hal_status != HAL_OK )
 	{
@@ -647,7 +653,7 @@ static BARO_STATUS load_cal_data
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 BARO_CAL_DATA_INT cal_data_int;       /* Raw calibration data from baro       */
 uint8_t           buffer[BARO_CAL_BUFFER_SIZE]; /* Buffer for cal data        */
@@ -655,19 +661,19 @@ BARO_STATUS       baro_status;        /* Baro API return codes                */
 
 
 /*------------------------------------------------------------------------------
- Initializations 
+ Initializations
 ------------------------------------------------------------------------------*/
 memset( &cal_data_int, 0, sizeof( cal_data_int ) );
 memset( &buffer[0]   , 0, sizeof( buffer       ) );
 
 
 /*------------------------------------------------------------------------------
- Read Baro Registers 
+ Read Baro Registers
 ------------------------------------------------------------------------------*/
 
 /* Get Data */
-baro_status = read_regs( BARO_REG_NVM_PAR_T1, 
-                         BARO_CAL_BUFFER_SIZE, 
+baro_status = read_regs( BARO_REG_NVM_PAR_T1,
+                         BARO_CAL_BUFFER_SIZE,
 						 &buffer[0] );
 if ( baro_status != BARO_OK )
 	{
@@ -692,7 +698,7 @@ cal_data_int.par_p11 = (int8_t) buffer[20];
 
 
 /*------------------------------------------------------------------------------
- Convert to floating point format ( BMP390 Datasheet pg. 55 ) 
+ Convert to floating point format ( BMP390 Datasheet pg. 55 )
 ------------------------------------------------------------------------------*/
 
 /* Temp Compensation */
@@ -736,25 +742,25 @@ static float temp_compensate
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 float partial_data1; /* Intermediate compensation results */
 float partial_data2;
 
 
 /*------------------------------------------------------------------------------
- Initializations 
+ Initializations
 ------------------------------------------------------------------------------*/
 partial_data1 = 0;
 partial_data2 = 0;
 
 
 /*------------------------------------------------------------------------------
- Calculations 
+ Calculations
 ------------------------------------------------------------------------------*/
 partial_data1 = (float)( raw_readout - baro_cal_data.par_t1 );
 partial_data2 = (float)( partial_data1*baro_cal_data.par_t2 );
-baro_cal_data.comp_temp = (float)( partial_data2 + 
+baro_cal_data.comp_temp = (float)( partial_data2 +
                             powf( partial_data1, 2)*baro_cal_data.par_t3 );
 return baro_cal_data.comp_temp;
 
@@ -770,13 +776,13 @@ return baro_cal_data.comp_temp;
 *       Apply the compensation formula to raw pressure readouts                *
 *                                                                              *
 *******************************************************************************/
-static float press_compensate 
+static float press_compensate
 	(
 	uint32_t raw_readout
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 float partial_data1; /* Intermediate compensation results */
 float partial_data2;
@@ -787,7 +793,7 @@ float partial_out2;
 
 
 /*------------------------------------------------------------------------------
- Initializations 
+ Initializations
 ------------------------------------------------------------------------------*/
 partial_data1 = 0;
 partial_data2 = 0;
@@ -798,27 +804,27 @@ partial_out2  = 0;
 
 
 /*------------------------------------------------------------------------------
- Calculations 
+ Calculations
 ------------------------------------------------------------------------------*/
 partial_data1 = baro_cal_data.par_p6*baro_cal_data.comp_temp;
 partial_data2 = baro_cal_data.par_p7*powf( baro_cal_data.comp_temp, 2 );
 partial_data3 = baro_cal_data.par_p8*powf( baro_cal_data.comp_temp, 3 );
-partial_out1  =  ( baro_cal_data.par_p5 + partial_data1 + 
+partial_out1  =  ( baro_cal_data.par_p5 + partial_data1 +
                    partial_data2        + partial_data3 );
 
 partial_data1 = baro_cal_data.par_p2*baro_cal_data.comp_temp;
 partial_data2 = baro_cal_data.par_p3*powf( baro_cal_data.comp_temp, 2 );
 partial_data3 = baro_cal_data.par_p4*powf( baro_cal_data.comp_temp, 3 );
-partial_out2  = (float) raw_readout*( baro_cal_data.par_p1 + 
+partial_out2  = (float) raw_readout*( baro_cal_data.par_p1 +
                                       partial_data1        +
 									  partial_data2        +
 									  partial_data3 );
 
 partial_data1 = powf( ( (float) raw_readout ), 2 );
-partial_data2 = ( baro_cal_data.par_p9 + 
+partial_data2 = ( baro_cal_data.par_p9 +
                   baro_cal_data.par_p10*baro_cal_data.comp_temp );
 partial_data3 = partial_data1*partial_data2;
-partial_data4 = ( partial_data3 + 
+partial_data4 = ( partial_data3 +
                   powf( ( (float) raw_readout ), 3 )*baro_cal_data.par_p11 );
 
 return partial_out1 + partial_out2 + partial_data4;
@@ -873,8 +879,8 @@ return write_reg( BARO_REG_CMD, BARO_CMD_FIFO_FLUSH );
 *******************************************************************************/
 bool baro_get_baro_data_ready
     (
-    void 
-    ) 
+    void
+    )
 {
 return baro_data_ready;
 
@@ -883,10 +889,10 @@ return baro_data_ready;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 * 		start_baro_read_IT                                                	   *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		Receive baro data in interrupt mode.	                               *
 *                                                                              *
 *******************************************************************************/
@@ -894,9 +900,9 @@ BARO_STATUS start_baro_read_IT
 	(
 	void
 	)
-{   
+{
 /*------------------------------------------------------------------------------
- Local variables  
+ Local variables
 ------------------------------------------------------------------------------*/
 HAL_StatusTypeDef hal_status;  /* HAL API Return codes */
 BARO_STATUS baro_status;       /* Return codes for baro API calls         */
@@ -911,7 +917,7 @@ baro_pres_proc = NAN;
 baro_temp_proc = NAN;
 
 /*------------------------------------------------------------------------------
- Implementation 
+ Implementation
 ------------------------------------------------------------------------------*/
 
 /* Set ready flag to false */
@@ -939,10 +945,10 @@ else
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 * 		baro_IT_handler                                                  	   *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		ISR for baro data reception. Heavy ISR.	Consider moving processing to  *
 *		get_baro_IT.								                           *
 *                                                                              *
@@ -953,7 +959,7 @@ BARO_STATUS baro_IT_handler
 	)
 {
 /*------------------------------------------------------------------------------
-Local variables 
+Local variables
 ------------------------------------------------------------------------------*/
 uint32_t    raw_pressure;      /* Pressure raw readout in uint32_t format */
 uint32_t 	raw_temp;		   /* Temp raw readout in uint32_t format*/
@@ -969,7 +975,7 @@ baro_status  = BARO_OK;
 
 
 /*------------------------------------------------------------------------------
-API function implementation 
+API function implementation
 ------------------------------------------------------------------------------*/
 
 /* Combine all bytes value to 24 bit value */
@@ -980,7 +986,7 @@ raw_pressure = ( ( (uint32_t) baro_raw_buffer[2] << 16 ) |
 				 /* Combine all bytes value to 24 bit value */
 raw_temp = ( ( (uint32_t) baro_raw_buffer[5] << 16 ) |
              ( (uint32_t) baro_raw_buffer[4] <<  8 ) |
-			 ( (uint32_t) baro_raw_buffer[3]       ) ); 
+			 ( (uint32_t) baro_raw_buffer[3]       ) );
 
 /* Adjust using calibration data */
 baro_temp_proc = temp_compensate( raw_temp );
@@ -996,10 +1002,10 @@ return baro_status;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   * 
+* PROCEDURE:                                                                   *
 * 		get_baro_it                   		                               	   *
 *                                                                              *
-* DESCRIPTION:                                                                 * 
+* DESCRIPTION:                                                                 *
 * 		Getter function for IT baro data.				                       *
 *                                                                              *
 *******************************************************************************/
@@ -1022,5 +1028,5 @@ return BARO_OK;
 
 
 /*******************************************************************************
-* END OF FILE                                                                  * 
+* END OF FILE                                                                  *
 *******************************************************************************/

--- a/baro/baro.c
+++ b/baro/baro.c
@@ -1,27 +1,27 @@
 /*******************************************************************************
 *
-* FILE:
+* FILE: 
 * 		baro.c
 *
-* DESCRIPTION:
+* DESCRIPTION: 
 * 		Contains API functions for the barometric pressure sensor
 *
-* COPYRIGHT:
-*       Copyright (c) 2025 Sun Devil Rocketry.
-*       All rights reserved.
-*
-*       This software is licensed under terms that can be found in the LICENSE
-*       file in the root directory of this software component.
-*       If no LICENSE file comes with this software, it is covered under the
-*       BSD-3-Clause.
-*
-*       https://opensource.org/license/bsd-3-clause
+* COPYRIGHT:                                                                   
+*       Copyright (c) 2025 Sun Devil Rocketry.                                 
+*       All rights reserved.                                                   
+*                                                                              
+*       This software is licensed under terms that can be found in the LICENSE 
+*       file in the root directory of this software component.                 
+*       If no LICENSE file comes with this software, it is covered under the   
+*       BSD-3-Clause.                                                          
+*                                                                              
+*       https://opensource.org/license/bsd-3-clause          
 *
 *******************************************************************************/
 
 
 /*------------------------------------------------------------------------------
- Standard Includes
+ Standard Includes                                                                     
 ------------------------------------------------------------------------------*/
 #include <stdbool.h>
 #include <string.h>
@@ -29,14 +29,14 @@
 #include <stdatomic.h>
 
 /*------------------------------------------------------------------------------
- Project Includes
+ Project Includes                                                                     
 ------------------------------------------------------------------------------*/
 #include "main.h"
 #include "sdr_pin_defines_A0002.h"
 #include "baro.h"
 
 /*------------------------------------------------------------------------------
-Global Variables
+Global Variables  
 ------------------------------------------------------------------------------*/
 
 /* Current Baro Sensor configuration */
@@ -52,7 +52,7 @@ static atomic_bool baro_data_ready = false;
 
 
 /*------------------------------------------------------------------------------
- Internal function prototypes
+ Internal function prototypes 
 ------------------------------------------------------------------------------*/
 
 /* Converts two bytes to uint16_t format */
@@ -87,9 +87,9 @@ static BARO_STATUS write_reg
 
 /* Configure/intialize the barometric pressure sensor */
 static BARO_STATUS baro_config
-		(
-		BARO_CONFIG* config_ptr
-		);
+	(
+	BARO_CONFIG* config_ptr
+	);
 
 /* Load the compensation data from the baro sensor */
 static BARO_STATUS load_cal_data
@@ -104,7 +104,7 @@ static float temp_compensate
 	);
 
 /* Apply the compensation formula to raw pressure readouts */
-static float press_compensate
+static float press_compensate 
 	(
 	uint32_t raw_readout
 	);
@@ -123,16 +123,16 @@ static BARO_STATUS baro_flush_fifo
 
 
 /*------------------------------------------------------------------------------
- API Functions
+ API Functions 
 ------------------------------------------------------------------------------*/
 
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 *       baro_init                                                              *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		Intialize the barometric pressure sensor                               *
 *                                                                              *
 *******************************************************************************/
@@ -142,7 +142,7 @@ BARO_STATUS baro_init
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 BARO_STATUS       baro_status;    /* Status code from Baro API calls   */
 uint8_t           baro_device_id; /* Baro device id                    */
@@ -151,7 +151,7 @@ float             init_temp;      /* Temperature read after init       */
 
 
 /*------------------------------------------------------------------------------
- Initializations
+ Initializations 
 ------------------------------------------------------------------------------*/
 baro_status    = BARO_OK;
 baro_device_id = 0;
@@ -160,7 +160,7 @@ init_temp      = 0;
 
 
 /*------------------------------------------------------------------------------
- API Function Implementation
+ API Function Implementation 
 ------------------------------------------------------------------------------*/
 
 /* Disable IRQ */
@@ -187,8 +187,8 @@ if ( baro_status != BARO_OK )
 HAL_Delay( 10 );
 
 /* Check the Baro error register */
-baro_status = read_regs( BARO_REG_ERR_REG      ,
-                         sizeof( baro_err_reg ),
+baro_status = read_regs( BARO_REG_ERR_REG      , 
+                         sizeof( baro_err_reg ), 
 						 &baro_err_reg );
 if ( baro_status != BARO_OK )
 	{
@@ -216,7 +216,7 @@ if ( baro_status != BARO_OK )
 /* Initialize the compensation temperature */
 baro_status = baro_get_temp( &init_temp );
 if ( baro_status != BARO_OK )
-	{
+	{ 
 	return baro_status;
 	}
 
@@ -235,10 +235,10 @@ return baro_status;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 *       baro_config                                                            *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		Configure the barometric pressure sensor                               *
 *                                                                              *
 *******************************************************************************/
@@ -248,7 +248,7 @@ static BARO_STATUS baro_config
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 BARO_STATUS   baro_status; /* Baro API call return codes                  */
 uint8_t       pwr_ctrl;    /* Contents of PWR_CTRL register               */
@@ -258,7 +258,7 @@ uint8_t       iir;         /* Contents of CONFIG register (IIR Filter)    */
 
 
 /*------------------------------------------------------------------------------
- Initializations
+ Initializations 
 ------------------------------------------------------------------------------*/
 baro_status = BARO_OK;
 pwr_ctrl    = 0;
@@ -268,7 +268,7 @@ iir         = 0;
 
 
 /*------------------------------------------------------------------------------
- Extract Baro settings from config struct
+ Extract Baro settings from config struct  
 ------------------------------------------------------------------------------*/
 
 /* Set register contents */
@@ -289,7 +289,7 @@ baro_configuration.IIR_setting       = config_ptr -> IIR_setting;
 
 
 /*------------------------------------------------------------------------------
- API function implementation
+ API function implementation 
 ------------------------------------------------------------------------------*/
 
 /* Write to the PWR_CTRL register -> Operating mode and enable sensors */
@@ -328,32 +328,32 @@ return BARO_OK;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 * 		baro_get_device_id                                                     *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		Gets the device ID of the barometric pressure sensor, primarily used   *
 *       to verify that the sensor can be accessed by the MCU                   *
 *                                                                              *
 *******************************************************************************/
 BARO_STATUS baro_get_device_id
 	(
-   	uint8_t* baro_id_ptr /* Out: Baro device id */
+   	uint8_t* baro_id_ptr /* Out: Baro device id */ 
 	)
 {
 /*------------------------------------------------------------------------------
- Local Variables
+ Local Variables 
 ------------------------------------------------------------------------------*/
 BARO_STATUS baro_status; /* Status codes returned from baro API calls */
 
 
 /*------------------------------------------------------------------------------
- API Function implementation
+ API Function implementation 
 ------------------------------------------------------------------------------*/
 
 /* Read baro register with I2C */
-baro_status = read_regs( BARO_REG_CHIP_ID,
-                         sizeof( uint8_t ),
+baro_status = read_regs( BARO_REG_CHIP_ID, 
+                         sizeof( uint8_t ), 
 						 baro_id_ptr );
 return baro_status;
 } /* baro_get_device_id */
@@ -361,10 +361,10 @@ return baro_status;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 * 		baro_get_pressure                                                      *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		retrieves a pressure reading from the sensor                           *
 *                                                                              *
 *******************************************************************************/
@@ -374,7 +374,7 @@ BARO_STATUS baro_get_pressure
 	)
 {
 /*------------------------------------------------------------------------------
-Local variables
+Local variables 
 ------------------------------------------------------------------------------*/
 uint8_t     pressure_bytes[3]; /* Pressure raw readout bytes, LSB first   */
 uint32_t    raw_pressure;      /* Pressure raw readout in uint32_t format */
@@ -392,12 +392,12 @@ memset( &pressure_bytes[0], 0, sizeof( pressure_bytes ) );
 
 
 /*------------------------------------------------------------------------------
-API function implementation
+API function implementation 
 ------------------------------------------------------------------------------*/
 
 /* Read 3 consecutive pressure data registers */
-baro_status = read_regs( BARO_REG_PRESS_DATA,
-                         sizeof( pressure_bytes ),
+baro_status = read_regs( BARO_REG_PRESS_DATA, 
+                         sizeof( pressure_bytes ), 
 						 &pressure_bytes[0] );
 if ( baro_status != BARO_OK )
 	{
@@ -421,20 +421,20 @@ return BARO_OK;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 * 		baro_get_temp                                                          *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		retrieves a temperature reading from the sensor                        *
 *                                                                              *
 *******************************************************************************/
 BARO_STATUS baro_get_temp
 	(
-    float* temp_ptr
+    float* temp_ptr 
 	)
 {
 /*------------------------------------------------------------------------------
-Local variables
+Local variables 
 ------------------------------------------------------------------------------*/
 uint8_t     temp_bytes[3]; /* Raw temperature readout bytes, LSB first */
 uint32_t    raw_temp;      /* Raw temperature readout in uint32_t format */
@@ -450,12 +450,12 @@ memset( &temp_bytes[0], 0, sizeof( temp_bytes ) );
 
 
 /*------------------------------------------------------------------------------
-API function implementation
+API function implementation 
 ------------------------------------------------------------------------------*/
 
 /* Read 3 consecutive temperature data registers */
-baro_status = read_regs( BARO_REG_TEMP_DATA  ,
-                         sizeof( temp_bytes ),
+baro_status = read_regs( BARO_REG_TEMP_DATA  , 
+                         sizeof( temp_bytes ), 
 						 &temp_bytes[0] );
 if ( baro_status != BARO_OK )
 	{
@@ -465,7 +465,7 @@ if ( baro_status != BARO_OK )
 /* Combine all bytes value to 24 bit value */
 raw_temp = ( ( (uint32_t) temp_bytes[2] << 16 ) |
              ( (uint32_t) temp_bytes[1] <<  8 ) |
-			 ( (uint32_t) temp_bytes[0]       ) );
+			 ( (uint32_t) temp_bytes[0]       ) ); 
 
 /* Adjust using calibration data */
 *temp_ptr = temp_compensate( raw_temp );
@@ -477,10 +477,10 @@ return BARO_OK;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 * 		baro_get_altitude                                                      *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		gets the altitude of the rocket from the sensor readouts               *
 *                                                                              *
 *******************************************************************************/
@@ -494,7 +494,7 @@ return BARO_OK;
 
 
 /*------------------------------------------------------------------------------
- Internal procedures
+ Internal procedures 
 ------------------------------------------------------------------------------*/
 
 
@@ -554,9 +554,9 @@ static BARO_STATUS read_regs
 	uint8_t  num_regs, /* In:  Number of registers to read */
 	uint8_t* pData     /* Out: Register contents           */
 	)
-{
+{   
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 HAL_StatusTypeDef hal_status;  /* HAL API Return codes */
 uint32_t          i2c_timeout; /* I2C read timeout     */
@@ -570,7 +570,7 @@ i2c_timeout = BARO_DEFAULT_TIMEOUT*num_regs;
 
 
 /*------------------------------------------------------------------------------
- Implementation
+ Implementation 
 ------------------------------------------------------------------------------*/
 
 /* Read I2C register*/
@@ -579,7 +579,7 @@ hal_status = HAL_I2C_Mem_Read( &( BARO_I2C )       ,
 				               reg_addr            ,
 				               I2C_MEMADD_SIZE_8BIT,
 				               pData               ,
-				               num_regs            ,
+				               num_regs            , 
 				               i2c_timeout );
 if ( hal_status != HAL_OK )
 	{
@@ -595,10 +595,10 @@ else
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 *       write_reg                                                              *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 *       Write to one of the baro's registers at a specified address            *
 *                                                                              *
 *******************************************************************************/
@@ -607,15 +607,15 @@ static BARO_STATUS write_reg
 	uint8_t  reg_addr, /* In: Register address            */
 	uint8_t  data      /* In: Register contents           */
 	)
-{
+{   
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 HAL_StatusTypeDef hal_status; /* HAL API Return codes */
 
 
 /*------------------------------------------------------------------------------
- Implementation
+ Implementation 
 ------------------------------------------------------------------------------*/
 
 /* Write to register with I2C */
@@ -624,7 +624,7 @@ hal_status = HAL_I2C_Mem_Write( &( BARO_I2C )       ,
 				                reg_addr            ,
 				                I2C_MEMADD_SIZE_8BIT,
 				                &data               ,
-				                sizeof( uint8_t )   ,
+				                sizeof( uint8_t )   , 
 				                BARO_DEFAULT_TIMEOUT );
 if ( hal_status != HAL_OK )
 	{
@@ -653,7 +653,7 @@ static BARO_STATUS load_cal_data
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 BARO_CAL_DATA_INT cal_data_int;       /* Raw calibration data from baro       */
 uint8_t           buffer[BARO_CAL_BUFFER_SIZE]; /* Buffer for cal data        */
@@ -661,19 +661,19 @@ BARO_STATUS       baro_status;        /* Baro API return codes                */
 
 
 /*------------------------------------------------------------------------------
- Initializations
+ Initializations 
 ------------------------------------------------------------------------------*/
 memset( &cal_data_int, 0, sizeof( cal_data_int ) );
 memset( &buffer[0]   , 0, sizeof( buffer       ) );
 
 
 /*------------------------------------------------------------------------------
- Read Baro Registers
+ Read Baro Registers 
 ------------------------------------------------------------------------------*/
 
 /* Get Data */
-baro_status = read_regs( BARO_REG_NVM_PAR_T1,
-                         BARO_CAL_BUFFER_SIZE,
+baro_status = read_regs( BARO_REG_NVM_PAR_T1, 
+                         BARO_CAL_BUFFER_SIZE, 
 						 &buffer[0] );
 if ( baro_status != BARO_OK )
 	{
@@ -698,7 +698,7 @@ cal_data_int.par_p11 = (int8_t) buffer[20];
 
 
 /*------------------------------------------------------------------------------
- Convert to floating point format ( BMP390 Datasheet pg. 55 )
+ Convert to floating point format ( BMP390 Datasheet pg. 55 ) 
 ------------------------------------------------------------------------------*/
 
 /* Temp Compensation */
@@ -742,25 +742,25 @@ static float temp_compensate
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 float partial_data1; /* Intermediate compensation results */
 float partial_data2;
 
 
 /*------------------------------------------------------------------------------
- Initializations
+ Initializations 
 ------------------------------------------------------------------------------*/
 partial_data1 = 0;
 partial_data2 = 0;
 
 
 /*------------------------------------------------------------------------------
- Calculations
+ Calculations 
 ------------------------------------------------------------------------------*/
 partial_data1 = (float)( raw_readout - baro_cal_data.par_t1 );
 partial_data2 = (float)( partial_data1*baro_cal_data.par_t2 );
-baro_cal_data.comp_temp = (float)( partial_data2 +
+baro_cal_data.comp_temp = (float)( partial_data2 + 
                             powf( partial_data1, 2)*baro_cal_data.par_t3 );
 return baro_cal_data.comp_temp;
 
@@ -776,13 +776,13 @@ return baro_cal_data.comp_temp;
 *       Apply the compensation formula to raw pressure readouts                *
 *                                                                              *
 *******************************************************************************/
-static float press_compensate
+static float press_compensate 
 	(
 	uint32_t raw_readout
 	)
 {
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 float partial_data1; /* Intermediate compensation results */
 float partial_data2;
@@ -793,7 +793,7 @@ float partial_out2;
 
 
 /*------------------------------------------------------------------------------
- Initializations
+ Initializations 
 ------------------------------------------------------------------------------*/
 partial_data1 = 0;
 partial_data2 = 0;
@@ -804,27 +804,27 @@ partial_out2  = 0;
 
 
 /*------------------------------------------------------------------------------
- Calculations
+ Calculations 
 ------------------------------------------------------------------------------*/
 partial_data1 = baro_cal_data.par_p6*baro_cal_data.comp_temp;
 partial_data2 = baro_cal_data.par_p7*powf( baro_cal_data.comp_temp, 2 );
 partial_data3 = baro_cal_data.par_p8*powf( baro_cal_data.comp_temp, 3 );
-partial_out1  =  ( baro_cal_data.par_p5 + partial_data1 +
+partial_out1  =  ( baro_cal_data.par_p5 + partial_data1 + 
                    partial_data2        + partial_data3 );
 
 partial_data1 = baro_cal_data.par_p2*baro_cal_data.comp_temp;
 partial_data2 = baro_cal_data.par_p3*powf( baro_cal_data.comp_temp, 2 );
 partial_data3 = baro_cal_data.par_p4*powf( baro_cal_data.comp_temp, 3 );
-partial_out2  = (float) raw_readout*( baro_cal_data.par_p1 +
+partial_out2  = (float) raw_readout*( baro_cal_data.par_p1 + 
                                       partial_data1        +
 									  partial_data2        +
 									  partial_data3 );
 
 partial_data1 = powf( ( (float) raw_readout ), 2 );
-partial_data2 = ( baro_cal_data.par_p9 +
+partial_data2 = ( baro_cal_data.par_p9 + 
                   baro_cal_data.par_p10*baro_cal_data.comp_temp );
 partial_data3 = partial_data1*partial_data2;
-partial_data4 = ( partial_data3 +
+partial_data4 = ( partial_data3 + 
                   powf( ( (float) raw_readout ), 3 )*baro_cal_data.par_p11 );
 
 return partial_out1 + partial_out2 + partial_data4;
@@ -879,8 +879,8 @@ return write_reg( BARO_REG_CMD, BARO_CMD_FIFO_FLUSH );
 *******************************************************************************/
 bool baro_get_baro_data_ready
     (
-    void
-    )
+    void 
+    ) 
 {
 return baro_data_ready;
 
@@ -889,10 +889,10 @@ return baro_data_ready;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 * 		start_baro_read_IT                                                	   *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		Receive baro data in interrupt mode.	                               *
 *                                                                              *
 *******************************************************************************/
@@ -900,9 +900,9 @@ BARO_STATUS start_baro_read_IT
 	(
 	void
 	)
-{
+{   
 /*------------------------------------------------------------------------------
- Local variables
+ Local variables  
 ------------------------------------------------------------------------------*/
 HAL_StatusTypeDef hal_status;  /* HAL API Return codes */
 BARO_STATUS baro_status;       /* Return codes for baro API calls         */
@@ -917,7 +917,7 @@ baro_pres_proc = NAN;
 baro_temp_proc = NAN;
 
 /*------------------------------------------------------------------------------
- Implementation
+ Implementation 
 ------------------------------------------------------------------------------*/
 
 /* Set ready flag to false */
@@ -945,10 +945,10 @@ else
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 * 		baro_IT_handler                                                  	   *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		ISR for baro data reception. Heavy ISR.	Consider moving processing to  *
 *		get_baro_IT.								                           *
 *                                                                              *
@@ -959,7 +959,7 @@ BARO_STATUS baro_IT_handler
 	)
 {
 /*------------------------------------------------------------------------------
-Local variables
+Local variables 
 ------------------------------------------------------------------------------*/
 uint32_t    raw_pressure;      /* Pressure raw readout in uint32_t format */
 uint32_t 	raw_temp;		   /* Temp raw readout in uint32_t format*/
@@ -975,7 +975,7 @@ baro_status  = BARO_OK;
 
 
 /*------------------------------------------------------------------------------
-API function implementation
+API function implementation 
 ------------------------------------------------------------------------------*/
 
 /* Combine all bytes value to 24 bit value */
@@ -986,7 +986,7 @@ raw_pressure = ( ( (uint32_t) baro_raw_buffer[2] << 16 ) |
 				 /* Combine all bytes value to 24 bit value */
 raw_temp = ( ( (uint32_t) baro_raw_buffer[5] << 16 ) |
              ( (uint32_t) baro_raw_buffer[4] <<  8 ) |
-			 ( (uint32_t) baro_raw_buffer[3]       ) );
+			 ( (uint32_t) baro_raw_buffer[3]       ) ); 
 
 /* Adjust using calibration data */
 baro_temp_proc = temp_compensate( raw_temp );
@@ -1002,10 +1002,10 @@ return baro_status;
 
 /*******************************************************************************
 *                                                                              *
-* PROCEDURE:                                                                   *
+* PROCEDURE:                                                                   * 
 * 		get_baro_it                   		                               	   *
 *                                                                              *
-* DESCRIPTION:                                                                 *
+* DESCRIPTION:                                                                 * 
 * 		Getter function for IT baro data.				                       *
 *                                                                              *
 *******************************************************************************/
@@ -1028,5 +1028,5 @@ return BARO_OK;
 
 
 /*******************************************************************************
-* END OF FILE                                                                  *
+* END OF FILE                                                                  * 
 *******************************************************************************/

--- a/baro/baro.c
+++ b/baro/baro.c
@@ -890,13 +890,13 @@ return baro_data_ready;
 /*******************************************************************************
 *                                                                              *
 * PROCEDURE:                                                                   * 
-* 		start_baro_read_IT                                                	   *
+* 		baro_start_read_IT                                                	   *
 *                                                                              *
 * DESCRIPTION:                                                                 * 
 * 		Receive baro data in interrupt mode.	                               *
 *                                                                              *
 *******************************************************************************/
-BARO_STATUS start_baro_read_IT
+BARO_STATUS baro_start_read_IT
 	(
 	void
 	)
@@ -940,7 +940,7 @@ else
 	return baro_status;
 	}
 
-} /* start_baro_read_IT */
+} /* baro_start_read_IT */
 
 
 /*******************************************************************************
@@ -950,7 +950,7 @@ else
 *                                                                              *
 * DESCRIPTION:                                                                 * 
 * 		ISR for baro data reception. Heavy ISR.	Consider moving processing to  *
-*		get_baro_IT.								                           *
+*		baro_get_it.								                           *
 *                                                                              *
 *******************************************************************************/
 BARO_STATUS baro_IT_handler
@@ -1003,13 +1003,13 @@ return baro_status;
 /*******************************************************************************
 *                                                                              *
 * PROCEDURE:                                                                   * 
-* 		get_baro_it                   		                               	   *
+* 		baro_get_it                   		                               	   *
 *                                                                              *
 * DESCRIPTION:                                                                 * 
 * 		Getter function for IT baro data.				                       *
 *                                                                              *
 *******************************************************************************/
-BARO_STATUS get_baro_it
+BARO_STATUS baro_get_it
 	(
 	float* pres_ptr, /* o: pressure */
 	float* temp_ptr  /* o: temperature */
@@ -1024,7 +1024,7 @@ if( !baro_data_ready )
 *temp_ptr = baro_temp_proc;
 
 return BARO_OK;
-} /* get_baro_it */
+} /* baro_get_it */
 
 
 /*******************************************************************************

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -30,10 +30,15 @@ extern "C" {
 
 #include "stm32h7xx_hal.h"
 
+#ifdef A0010
+#include "sdr_pin_defines_A0010.h"
+#endif
+
 /*------------------------------------------------------------------------------
  Macros 
 ------------------------------------------------------------------------------*/
 
+#ifdef A0002_REV2
 /* I2C Device Params */
 #define BARO_I2C_ADDR	    ( 0x76 << 1 )	/* 1110110 -> 0x76 */
 
@@ -80,7 +85,7 @@ extern "C" {
 /* Baro sensor command codes */
 #define BARO_CMD_RESET          ( 0xB6 )
 #define BARO_CMD_FIFO_FLUSH     ( 0xB0 )
-
+#endif
 
 /*------------------------------------------------------------------------------
  Typdefs 
@@ -95,9 +100,18 @@ typedef enum _BARO_STATUS
 	BARO_UNRECOGNIZED_HAL_STATUS,
 	BARO_UNSUPPORTED_CONFIG     ,
 	BARO_UNRECOGNIZED_CHIP_ID   ,
+	#ifdef A00100               ,
+	/* If the CRC check on r3 baro memory fails */
+	BARO_INVALID_PROM,
+	#endif
 	BARO_ERROR                  ,
 	BARO_CAL_ERROR              ,
+	#ifdef A0002_REV2
 	BARO_I2C_ERROR              ,
+	#endif
+	#ifdef A0010
+	BARO_SPI_ERROR              ,
+	#endif
 	BARO_CANNOT_RESET           ,
 	BARO_FIFO_ERROR				,
 	BARO_BUSY
@@ -112,6 +126,7 @@ typedef enum _BARO_SENSOR_ENABLES
 	BARO_PRESS_TEMP_ENABLED = 3
 	} BARO_SENSOR_ENABLES;
 
+#ifdef A0002_REV2
 /* Operating mode of baro sensor */
 typedef enum _BARO_MODE
 	{
@@ -119,29 +134,52 @@ typedef enum _BARO_MODE
 	BARO_FORCED_MODE = 1,
 	BARO_NORMAL_MODE = 3
 	} BARO_MODE;
-
+#endif
+	
 /* Pressure Sensor Oversampling Settings */
 typedef enum _BARO_PRESS_OSR_SETTING
 	{
+	#ifdef A0002_REV2
 	BARO_PRESS_OSR_X1 = 0,
     BARO_PRESS_OSR_X2    ,
 	BARO_PRESS_OSR_X4    ,
 	BARO_PRESS_OSR_X8    ,
 	BARO_PRESS_OSR_X16   ,
 	BARO_PRESS_OSR_X32
+	#endif
+	/* Prevent any possibility that vals get misinterpreted between revs */
+	#ifdef A0010
+	BARO_PRESS_OSR_X256 = 6,
+	BARO_PRESS_OSR_X512    ,
+	BARO_PRESS_OSR_X1024   ,
+	BARO_PRESS_OSR_X2048   ,
+	BARO_PRESS_OSR_X4096
+	#endif
 	} BARO_PRESS_OSR_SETTING;
 
 /* Temperature Sensor Oversampling Settings */
 typedef enum _BARO_TEMP_OSR_SETTING
 	{
+	#ifdef A0002_REV2
 	BARO_TEMP_OSR_X1 = 0,
     BARO_TEMP_OSR_X2    ,
 	BARO_TEMP_OSR_X4    ,
 	BARO_TEMP_OSR_X8    ,
 	BARO_TEMP_OSR_X16   ,
 	BARO_TEMP_OSR_X32
+	#endif
+	/* Prevent any possibility that vals get misinterpreted between revs */
+	#ifdef A0010
+	BARO_TEMP_OSR_X256 = 6,
+	BARO_TEMP_OSR_X512    ,
+	BARO_TEMP_OSR_X1024   ,
+	BARO_TEMP_OSR_X2048   ,
+	BARO_TEMP_OSR_X4096
+	#endif
 	} BARO_TEMP_OSR_SETTING;
 
+
+#ifdef A0002_REV2
 /* Sample Frequency settings */
 typedef enum _BARO_ODR_SETTING
 	{
@@ -155,7 +193,7 @@ typedef enum _BARO_ODR_SETTING
 	BARO_ODR_25_16HZ  ,
 	BARO_ODR_25_32HZ
 	} BARO_ODR_SETTING;
-
+	
 /* IIR Filter coefficient selection */
 typedef enum _BARO_IIR_SETTING
 	{
@@ -168,15 +206,18 @@ typedef enum _BARO_IIR_SETTING
 	BARO_IIR_COEF_63  = 6,
 	BARO_IIR_COEF_127 = 7 
 	} BARO_IIR_SETTING;
-
+#endif
+	
 /* Baro sensor configuration settings struct */
 typedef struct _BARO_CONFIG
 	{
 	/* Sensor enables */
 	BARO_SENSOR_ENABLES enable;
 
+	#ifdef A0002_REV2
 	/* Operating mode */
 	BARO_MODE mode;
+	#endif
 
 	/* Pressure Oversampling setting  */
 	BARO_PRESS_OSR_SETTING press_OSR_setting;
@@ -184,14 +225,22 @@ typedef struct _BARO_CONFIG
 	/* Temperature Oversampling setting */
 	BARO_TEMP_OSR_SETTING temp_OSR_setting;
 
+	#ifdef A0002_REV2
 	/* Sampling frequency */
 	BARO_ODR_SETTING ODR_setting;
 
 	/* IIR Filter Coefficient Selection */
 	BARO_IIR_SETTING IIR_setting;
-
+	#endif
 	} BARO_CONFIG;
 
+
+/* These structs are static to the rev3 implementation.
+* They should be for rev2 as well, but aren't.
+* I'm leaving it this way for rev2 code because emulator
+* depends on it.
+*/
+#ifdef A0002_REV2
 /* Baro calibration data struct in integer format */
 typedef struct _BARO_CAL_DATA_INT
 	{
@@ -239,7 +288,7 @@ typedef struct _BARO_CAL_DATA
 	float comp_temp;
 
 	} BARO_CAL_DATA;
-
+#endif
 
 /*------------------------------------------------------------------------------
  Function Prototypes 
@@ -250,20 +299,27 @@ BARO_STATUS baro_init
 	(
 	BARO_CONFIG* config_ptr
 	);
-	
-/* Configure/intialize the barometric pressure sensor */
-BARO_STATUS baro_config
-	(
-	BARO_CONFIG* config_ptr 
-	);
 
+#ifdef A0002_REV2
 /* verifies sensor can be accessed */
 BARO_STATUS baro_get_device_id
 	(
    	uint8_t* baro_id 
 	);
+#endif
 
+#ifdef A0010
+/* verifies sensor can be accessed */
+/* The serial is 12 bits on the rev 3 sensor */
+BARO_STATUS baro_get_device_id
+	(
+   	uint8_t* baro_id 
+   	uint16_t* baro_id
+	);
+#endif
 
+/* Blocking implementations are not supported on r3 */
+#ifdef A0002_REV2
 /* gets pressure data from sensor */
 BARO_STATUS baro_get_pressure
 	(
@@ -281,7 +337,8 @@ BARO_STATUS baro_get_altitude
 	(
     void
 	);
-
+#endif
+	
 /* returns the baro_data_ready flag */
 bool baro_get_baro_data_ready
     (

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -345,7 +345,7 @@ bool baro_get_baro_data_ready
 
 BARO_STATUS baro_start_read_IT();
 BARO_STATUS baro_IT_handler();
-BARO_STATUS baro_get_it(float* pres_ptr, float* temp_ptr);
+BARO_STATUS baro_get_IT(float* pres_ptr, float* temp_ptr);
 
 
 #ifdef __cplusplus

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -106,6 +106,9 @@ typedef enum _BARO_STATUS
 	#ifdef A0002_REV2
 	BARO_I2C_ERROR              ,
 	#endif
+	#ifdef A0010
+	BARO_SPI_ERROR              ,
+	#endif
 	BARO_CANNOT_RESET           ,
 	BARO_FIFO_ERROR				,
 	BARO_BUSY

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -343,9 +343,9 @@ bool baro_get_baro_data_ready
     void 
     );
 
-BARO_STATUS start_baro_read_IT();
+BARO_STATUS baro_start_read_IT();
 BARO_STATUS baro_IT_handler();
-BARO_STATUS get_baro_it(float* pres_ptr, float* temp_ptr);
+BARO_STATUS baro_get_it(float* pres_ptr, float* temp_ptr);
 
 
 #ifdef __cplusplus

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -1,39 +1,41 @@
 /*******************************************************************************
 *
-* FILE: 
+* FILE:
 * 		baro.h
 *
-* DESCRIPTION: 
+* DESCRIPTION:
 * 		Contains API functions for the barometric pressure sensor
 *
-* COPYRIGHT:                                                                   
-*       Copyright (c) 2025 Sun Devil Rocketry.                                 
-*       All rights reserved.                                                   
-*                                                                              
-*       This software is licensed under terms that can be found in the LICENSE 
-*       file in the root directory of this software component.                 
-*       If no LICENSE file comes with this software, it is covered under the   
-*       BSD-3-Clause.                                                          
-*                                                                              
-*       https://opensource.org/license/bsd-3-clause          
+* COPYRIGHT:
+*       Copyright (c) 2025 Sun Devil Rocketry.
+*       All rights reserved.
+*
+*       This software is licensed under terms that can be found in the LICENSE
+*       file in the root directory of this software component.
+*       If no LICENSE file comes with this software, it is covered under the
+*       BSD-3-Clause.
+*
+*       https://opensource.org/license/bsd-3-clause
 *
 *******************************************************************************/
 
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef BARO_H 
-#define BARO_H 
+#ifndef BARO_H
+#define BARO_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include "stm32h7xx_hal.h"
+#include "sdr_pin_defines_A0010.h"
 
 /*------------------------------------------------------------------------------
- Macros 
+ Macros
 ------------------------------------------------------------------------------*/
 
+#ifdef A0002_REV2
 /* I2C Device Params */
 #define BARO_I2C_ADDR	    ( 0x76 << 1 )	/* 1110110 -> 0x76 */
 
@@ -41,10 +43,10 @@ extern "C" {
 /* Barometric Pressure Sensor register addresses */
 #define BARO_REG_CHIP_ID        ( 0x00 )
 #define BARO_REG_ERR_REG        ( 0x02 )
-#define BARO_REG_PRESS_DATA     ( 0x04 )  
-#define BARO_REG_TEMP_DATA      ( 0x07 ) 
+#define BARO_REG_PRESS_DATA     ( 0x04 )
+#define BARO_REG_TEMP_DATA      ( 0x07 )
 #define BARO_REG_PWR_CTRL       ( 0x1B )
-#define BARO_REG_OSR            ( 0x1C ) 
+#define BARO_REG_OSR            ( 0x1C )
 #define BARO_REG_ODR            ( 0x1D )
 #define BARO_REG_CONFIG         ( 0x1F )
 #define BARO_REG_NVM_PAR_T1     ( 0x31 )
@@ -80,24 +82,30 @@ extern "C" {
 /* Baro sensor command codes */
 #define BARO_CMD_RESET          ( 0xB6 )
 #define BARO_CMD_FIFO_FLUSH     ( 0xB0 )
-
+#endif
 
 /*------------------------------------------------------------------------------
- Typdefs 
+ Typdefs
 ------------------------------------------------------------------------------*/
 
 /* Return codes for API functions */
 typedef enum _BARO_STATUS
 	{
 	BARO_OK                   =0,
-	BARO_FAIL                   , 
+	BARO_FAIL                   ,
 	BARO_TIMEOUT                ,
 	BARO_UNRECOGNIZED_HAL_STATUS,
 	BARO_UNSUPPORTED_CONFIG     ,
 	BARO_UNRECOGNIZED_CHIP_ID   ,
+	#ifdef A00100               ,
+	/* If the CRC check on r3 baro memory fails */
+	BARO_INVALID_PROM,
+	#endif
 	BARO_ERROR                  ,
 	BARO_CAL_ERROR              ,
+	#ifdef A0002_REV2
 	BARO_I2C_ERROR              ,
+	#endif
 	BARO_CANNOT_RESET           ,
 	BARO_FIFO_ERROR				,
 	BARO_BUSY
@@ -112,6 +120,7 @@ typedef enum _BARO_SENSOR_ENABLES
 	BARO_PRESS_TEMP_ENABLED = 3
 	} BARO_SENSOR_ENABLES;
 
+#ifdef A0002_REV2
 /* Operating mode of baro sensor */
 typedef enum _BARO_MODE
 	{
@@ -119,29 +128,51 @@ typedef enum _BARO_MODE
 	BARO_FORCED_MODE = 1,
 	BARO_NORMAL_MODE = 3
 	} BARO_MODE;
+#endif
 
 /* Pressure Sensor Oversampling Settings */
 typedef enum _BARO_PRESS_OSR_SETTING
 	{
+	#ifdef A0002_REV2
 	BARO_PRESS_OSR_X1 = 0,
     BARO_PRESS_OSR_X2    ,
 	BARO_PRESS_OSR_X4    ,
 	BARO_PRESS_OSR_X8    ,
 	BARO_PRESS_OSR_X16   ,
 	BARO_PRESS_OSR_X32
+	#endif
+	/* Prevent any possibility that vals get misinterpreted between revs */
+	#ifdef A0010
+	BARO_PRESS_OSR_X256 = 6,
+	BARO_PRESS_OSR_X512    ,
+	BARO_PRESS_OSR_X1024   ,
+	BARO_PRESS_OSR_X2048   ,
+	BARO_PRESS_OSR_X4096
+	#endif
 	} BARO_PRESS_OSR_SETTING;
 
 /* Temperature Sensor Oversampling Settings */
 typedef enum _BARO_TEMP_OSR_SETTING
 	{
+	#ifdef A0002_REV2
 	BARO_TEMP_OSR_X1 = 0,
     BARO_TEMP_OSR_X2    ,
 	BARO_TEMP_OSR_X4    ,
 	BARO_TEMP_OSR_X8    ,
 	BARO_TEMP_OSR_X16   ,
 	BARO_TEMP_OSR_X32
+	#endif
+	/* Prevent any possibility that vals get misinterpreted between revs */
+	#ifdef A0010
+	BARO_TEMP_OSR_X256 = 6,
+	BARO_TEMP_OSR_X512    ,
+	BARO_TEMP_OSR_X1024   ,
+	BARO_TEMP_OSR_X2048   ,
+	BARO_TEMP_OSR_X4096
+	#endif
 	} BARO_TEMP_OSR_SETTING;
 
+#ifdef A0002_REV2
 /* Sample Frequency settings */
 typedef enum _BARO_ODR_SETTING
 	{
@@ -166,8 +197,9 @@ typedef enum _BARO_IIR_SETTING
 	BARO_IIR_COEF_15  = 4,
 	BARO_IIR_COEF_31  = 5,
 	BARO_IIR_COEF_63  = 6,
-	BARO_IIR_COEF_127 = 7 
+	BARO_IIR_COEF_127 = 7
 	} BARO_IIR_SETTING;
+#endif
 
 /* Baro sensor configuration settings struct */
 typedef struct _BARO_CONFIG
@@ -175,8 +207,10 @@ typedef struct _BARO_CONFIG
 	/* Sensor enables */
 	BARO_SENSOR_ENABLES enable;
 
+	#ifdef A0002_REV2
 	/* Operating mode */
 	BARO_MODE mode;
+	#endif
 
 	/* Pressure Oversampling setting  */
 	BARO_PRESS_OSR_SETTING press_OSR_setting;
@@ -184,14 +218,21 @@ typedef struct _BARO_CONFIG
 	/* Temperature Oversampling setting */
 	BARO_TEMP_OSR_SETTING temp_OSR_setting;
 
+	#ifdef A0002_REV2
 	/* Sampling frequency */
 	BARO_ODR_SETTING ODR_setting;
 
 	/* IIR Filter Coefficient Selection */
 	BARO_IIR_SETTING IIR_setting;
-
+	#endif
 	} BARO_CONFIG;
 
+/* These structs are static to the rev3 implementation.
+ * They should be for rev2 as well, but aren't.
+ * I'm leaving it this way for rev2 code because emulator
+ * depends on it.
+ */
+#ifdef A0002_REV2
 /* Baro calibration data struct in integer format */
 typedef struct _BARO_CAL_DATA_INT
 	{
@@ -239,10 +280,10 @@ typedef struct _BARO_CAL_DATA
 	float comp_temp;
 
 	} BARO_CAL_DATA;
-
+#endif
 
 /*------------------------------------------------------------------------------
- Function Prototypes 
+ Function Prototypes
 ------------------------------------------------------------------------------*/
 
 /* Intialize the barometric pressure sensor */
@@ -250,30 +291,36 @@ BARO_STATUS baro_init
 	(
 	BARO_CONFIG* config_ptr
 	);
-	
-/* Configure/intialize the barometric pressure sensor */
-BARO_STATUS baro_config
-	(
-	BARO_CONFIG* config_ptr 
-	);
 
+#ifdef A0002_REV2
 /* verifies sensor can be accessed */
 BARO_STATUS baro_get_device_id
 	(
-   	uint8_t* baro_id 
+   	uint8_t* baro_id
 	);
+#endif
 
+#ifdef A0010
+/* verifies sensor can be accessed */
+/* The serial is 12 bits on the rev 3 sensor */
+BARO_STATUS baro_get_device_id
+	(
+   	uint16_t* baro_id
+	);
+#endif
 
+/* Blocking implementations are not supported on r3 */
+#ifdef A0002_REV2
 /* gets pressure data from sensor */
 BARO_STATUS baro_get_pressure
 	(
-    float* pressure_ptr 
+    float* pressure_ptr
 	);
 
 /* gets temp data from sensor */
 BARO_STATUS baro_get_temp
 	(
-    float* temp_ptr 
+    float* temp_ptr
 	);
 
 /* converts pressure and temp data into altitude --> do research on formula */
@@ -281,11 +328,12 @@ BARO_STATUS baro_get_altitude
 	(
     void
 	);
+#endif
 
 /* returns the baro_data_ready flag */
 bool baro_get_baro_data_ready
     (
-    void 
+    void
     );
 
 BARO_STATUS start_baro_read_IT();
@@ -299,5 +347,5 @@ BARO_STATUS get_baro_it(float* pres_ptr, float* temp_ptr);
 #endif /* BARO_H */
 
 /*******************************************************************************
-* END OF FILE                                                                  * 
+* END OF FILE                                                                  *
 *******************************************************************************/

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -193,7 +193,7 @@ typedef enum _BARO_ODR_SETTING
 	BARO_ODR_25_16HZ  ,
 	BARO_ODR_25_32HZ
 	} BARO_ODR_SETTING;
-	
+
 /* IIR Filter coefficient selection */
 typedef enum _BARO_IIR_SETTING
 	{

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -214,11 +214,6 @@ typedef struct _BARO_CONFIG
 	/* Sensor enables */
 	BARO_SENSOR_ENABLES enable;
 
-	#ifdef A0002_REV2
-	/* Operating mode */
-	BARO_MODE mode;
-	#endif
-
 	/* Pressure Oversampling setting  */
 	BARO_PRESS_OSR_SETTING press_OSR_setting;
 
@@ -226,6 +221,9 @@ typedef struct _BARO_CONFIG
 	BARO_TEMP_OSR_SETTING temp_OSR_setting;
 
 	#ifdef A0002_REV2
+	/* Operating mode */
+	BARO_MODE mode;
+	
 	/* Sampling frequency */
 	BARO_ODR_SETTING ODR_setting;
 

--- a/baro/baro.h
+++ b/baro/baro.h
@@ -1,41 +1,39 @@
 /*******************************************************************************
 *
-* FILE:
+* FILE: 
 * 		baro.h
 *
-* DESCRIPTION:
+* DESCRIPTION: 
 * 		Contains API functions for the barometric pressure sensor
 *
-* COPYRIGHT:
-*       Copyright (c) 2025 Sun Devil Rocketry.
-*       All rights reserved.
-*
-*       This software is licensed under terms that can be found in the LICENSE
-*       file in the root directory of this software component.
-*       If no LICENSE file comes with this software, it is covered under the
-*       BSD-3-Clause.
-*
-*       https://opensource.org/license/bsd-3-clause
+* COPYRIGHT:                                                                   
+*       Copyright (c) 2025 Sun Devil Rocketry.                                 
+*       All rights reserved.                                                   
+*                                                                              
+*       This software is licensed under terms that can be found in the LICENSE 
+*       file in the root directory of this software component.                 
+*       If no LICENSE file comes with this software, it is covered under the   
+*       BSD-3-Clause.                                                          
+*                                                                              
+*       https://opensource.org/license/bsd-3-clause          
 *
 *******************************************************************************/
 
 
 /* Define to prevent recursive inclusion -------------------------------------*/
-#ifndef BARO_H
-#define BARO_H
+#ifndef BARO_H 
+#define BARO_H 
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include "stm32h7xx_hal.h"
-#include "sdr_pin_defines_A0010.h"
 
 /*------------------------------------------------------------------------------
- Macros
+ Macros 
 ------------------------------------------------------------------------------*/
 
-#ifdef A0002_REV2
 /* I2C Device Params */
 #define BARO_I2C_ADDR	    ( 0x76 << 1 )	/* 1110110 -> 0x76 */
 
@@ -43,10 +41,10 @@ extern "C" {
 /* Barometric Pressure Sensor register addresses */
 #define BARO_REG_CHIP_ID        ( 0x00 )
 #define BARO_REG_ERR_REG        ( 0x02 )
-#define BARO_REG_PRESS_DATA     ( 0x04 )
-#define BARO_REG_TEMP_DATA      ( 0x07 )
+#define BARO_REG_PRESS_DATA     ( 0x04 )  
+#define BARO_REG_TEMP_DATA      ( 0x07 ) 
 #define BARO_REG_PWR_CTRL       ( 0x1B )
-#define BARO_REG_OSR            ( 0x1C )
+#define BARO_REG_OSR            ( 0x1C ) 
 #define BARO_REG_ODR            ( 0x1D )
 #define BARO_REG_CONFIG         ( 0x1F )
 #define BARO_REG_NVM_PAR_T1     ( 0x31 )
@@ -82,33 +80,24 @@ extern "C" {
 /* Baro sensor command codes */
 #define BARO_CMD_RESET          ( 0xB6 )
 #define BARO_CMD_FIFO_FLUSH     ( 0xB0 )
-#endif
+
 
 /*------------------------------------------------------------------------------
- Typdefs
+ Typdefs 
 ------------------------------------------------------------------------------*/
 
 /* Return codes for API functions */
 typedef enum _BARO_STATUS
 	{
 	BARO_OK                   =0,
-	BARO_FAIL                   ,
+	BARO_FAIL                   , 
 	BARO_TIMEOUT                ,
 	BARO_UNRECOGNIZED_HAL_STATUS,
 	BARO_UNSUPPORTED_CONFIG     ,
 	BARO_UNRECOGNIZED_CHIP_ID   ,
-	#ifdef A00100               ,
-	/* If the CRC check on r3 baro memory fails */
-	BARO_INVALID_PROM,
-	#endif
 	BARO_ERROR                  ,
 	BARO_CAL_ERROR              ,
-	#ifdef A0002_REV2
 	BARO_I2C_ERROR              ,
-	#endif
-	#ifdef A0010
-	BARO_SPI_ERROR              ,
-	#endif
 	BARO_CANNOT_RESET           ,
 	BARO_FIFO_ERROR				,
 	BARO_BUSY
@@ -123,7 +112,6 @@ typedef enum _BARO_SENSOR_ENABLES
 	BARO_PRESS_TEMP_ENABLED = 3
 	} BARO_SENSOR_ENABLES;
 
-#ifdef A0002_REV2
 /* Operating mode of baro sensor */
 typedef enum _BARO_MODE
 	{
@@ -131,51 +119,29 @@ typedef enum _BARO_MODE
 	BARO_FORCED_MODE = 1,
 	BARO_NORMAL_MODE = 3
 	} BARO_MODE;
-#endif
 
 /* Pressure Sensor Oversampling Settings */
 typedef enum _BARO_PRESS_OSR_SETTING
 	{
-	#ifdef A0002_REV2
 	BARO_PRESS_OSR_X1 = 0,
     BARO_PRESS_OSR_X2    ,
 	BARO_PRESS_OSR_X4    ,
 	BARO_PRESS_OSR_X8    ,
 	BARO_PRESS_OSR_X16   ,
 	BARO_PRESS_OSR_X32
-	#endif
-	/* Prevent any possibility that vals get misinterpreted between revs */
-	#ifdef A0010
-	BARO_PRESS_OSR_X256 = 6,
-	BARO_PRESS_OSR_X512    ,
-	BARO_PRESS_OSR_X1024   ,
-	BARO_PRESS_OSR_X2048   ,
-	BARO_PRESS_OSR_X4096
-	#endif
 	} BARO_PRESS_OSR_SETTING;
 
 /* Temperature Sensor Oversampling Settings */
 typedef enum _BARO_TEMP_OSR_SETTING
 	{
-	#ifdef A0002_REV2
 	BARO_TEMP_OSR_X1 = 0,
     BARO_TEMP_OSR_X2    ,
 	BARO_TEMP_OSR_X4    ,
 	BARO_TEMP_OSR_X8    ,
 	BARO_TEMP_OSR_X16   ,
 	BARO_TEMP_OSR_X32
-	#endif
-	/* Prevent any possibility that vals get misinterpreted between revs */
-	#ifdef A0010
-	BARO_TEMP_OSR_X256 = 6,
-	BARO_TEMP_OSR_X512    ,
-	BARO_TEMP_OSR_X1024   ,
-	BARO_TEMP_OSR_X2048   ,
-	BARO_TEMP_OSR_X4096
-	#endif
 	} BARO_TEMP_OSR_SETTING;
 
-#ifdef A0002_REV2
 /* Sample Frequency settings */
 typedef enum _BARO_ODR_SETTING
 	{
@@ -200,9 +166,8 @@ typedef enum _BARO_IIR_SETTING
 	BARO_IIR_COEF_15  = 4,
 	BARO_IIR_COEF_31  = 5,
 	BARO_IIR_COEF_63  = 6,
-	BARO_IIR_COEF_127 = 7
+	BARO_IIR_COEF_127 = 7 
 	} BARO_IIR_SETTING;
-#endif
 
 /* Baro sensor configuration settings struct */
 typedef struct _BARO_CONFIG
@@ -210,10 +175,8 @@ typedef struct _BARO_CONFIG
 	/* Sensor enables */
 	BARO_SENSOR_ENABLES enable;
 
-	#ifdef A0002_REV2
 	/* Operating mode */
 	BARO_MODE mode;
-	#endif
 
 	/* Pressure Oversampling setting  */
 	BARO_PRESS_OSR_SETTING press_OSR_setting;
@@ -221,21 +184,14 @@ typedef struct _BARO_CONFIG
 	/* Temperature Oversampling setting */
 	BARO_TEMP_OSR_SETTING temp_OSR_setting;
 
-	#ifdef A0002_REV2
 	/* Sampling frequency */
 	BARO_ODR_SETTING ODR_setting;
 
 	/* IIR Filter Coefficient Selection */
 	BARO_IIR_SETTING IIR_setting;
-	#endif
+
 	} BARO_CONFIG;
 
-/* These structs are static to the rev3 implementation.
- * They should be for rev2 as well, but aren't.
- * I'm leaving it this way for rev2 code because emulator
- * depends on it.
- */
-#ifdef A0002_REV2
 /* Baro calibration data struct in integer format */
 typedef struct _BARO_CAL_DATA_INT
 	{
@@ -283,10 +239,10 @@ typedef struct _BARO_CAL_DATA
 	float comp_temp;
 
 	} BARO_CAL_DATA;
-#endif
+
 
 /*------------------------------------------------------------------------------
- Function Prototypes
+ Function Prototypes 
 ------------------------------------------------------------------------------*/
 
 /* Intialize the barometric pressure sensor */
@@ -294,36 +250,30 @@ BARO_STATUS baro_init
 	(
 	BARO_CONFIG* config_ptr
 	);
+	
+/* Configure/intialize the barometric pressure sensor */
+BARO_STATUS baro_config
+	(
+	BARO_CONFIG* config_ptr 
+	);
 
-#ifdef A0002_REV2
 /* verifies sensor can be accessed */
 BARO_STATUS baro_get_device_id
 	(
-   	uint8_t* baro_id
+   	uint8_t* baro_id 
 	);
-#endif
 
-#ifdef A0010
-/* verifies sensor can be accessed */
-/* The serial is 12 bits on the rev 3 sensor */
-BARO_STATUS baro_get_device_id
-	(
-   	uint16_t* baro_id
-	);
-#endif
 
-/* Blocking implementations are not supported on r3 */
-#ifdef A0002_REV2
 /* gets pressure data from sensor */
 BARO_STATUS baro_get_pressure
 	(
-    float* pressure_ptr
+    float* pressure_ptr 
 	);
 
 /* gets temp data from sensor */
 BARO_STATUS baro_get_temp
 	(
-    float* temp_ptr
+    float* temp_ptr 
 	);
 
 /* converts pressure and temp data into altitude --> do research on formula */
@@ -331,12 +281,11 @@ BARO_STATUS baro_get_altitude
 	(
     void
 	);
-#endif
 
 /* returns the baro_data_ready flag */
 bool baro_get_baro_data_ready
     (
-    void
+    void 
     );
 
 BARO_STATUS start_baro_read_IT();
@@ -350,5 +299,5 @@ BARO_STATUS get_baro_it(float* pres_ptr, float* temp_ptr);
 #endif /* BARO_H */
 
 /*******************************************************************************
-* END OF FILE                                                                  *
+* END OF FILE                                                                  * 
 *******************************************************************************/

--- a/baro/baro_r3.c
+++ b/baro/baro_r3.c
@@ -1,7 +1,7 @@
 /**
   ******************************************************************************
   * @file           : baro_r3.c
-  * @brief          : Driver for the barometer on FC rev 3.
+  * @brief          : Driver for the MS5607-02BA03 barometer on FC rev 3.
   ******************************************************************************
   * @copyright
   *
@@ -16,16 +16,9 @@
   * https://opensource.org/license/bsd-3-clause
   */
 
-/*
- * Implementation Notes
- * I think we can create a TIM_OC_InitTypeDef, configure HAL_TIM_OC_ConfigChannel in a channel,
- * and then run HAL_TIM_OC_Start. Our callback is then HAL_TIM_OC_DelayElapsedCallback().
- */
-
 /* Includes ------------------------------------------------------------------*/
 
 /* Standard */
-#include <cstdint>
 #include <stdbool.h>
 #include <stdatomic.h>
 
@@ -36,6 +29,8 @@
 #include "baro.h"
 
 /* Type Definitions ----------------------------------------------------------*/
+
+/* Baro calibration data struct in integer format */
 typedef struct _BARO_CAL_DATA_INT
 	{
 	uint16_t par_c1; // Pressure Sensitity
@@ -46,13 +41,262 @@ typedef struct _BARO_CAL_DATA_INT
 	uint16_t par_c6; // Temp. Coeff. of Temperature
 	} BARO_CAL_DATA_INT;
 
+/* States for FSM to read data */
+typedef enum _BARO_READ_STATE
+    {
+    BARO_CONV_PRESSURE,    // Start pressure Conversion
+    BARO_WAIT_PRESSURE,    // Pressure Conversion Wait
+    BARO_READ_PRESSURE,    // Start pressure ADC Read
+    BARO_CONV_TEMPERATURE, // Start Temp Conversion
+    BARO_WAIT_TEMPERATURE, // Temp Conversion Wait
+    BARO_READ_TEMPERATURE, // Start Temperature ADC Read
+    BARO_READ_FINISH,      // Complete sensor reading
+    BARO_READ_DONE,         // Done
+    BARO_READ_FAIL
+    } BARO_READ_STATE;
 /* Global Variables ----------------------------------------------------------*/
 
 /* Current Baro Sensor configuration */
 static BARO_CONFIG   baro_configuration;
 
 /* Baro calibration coefficients for measurement compensation */
-static BARO_CAL_DATA baro_cal_data;
+static BARO_CAL_DATA_INT baro_cal_data;
 
-static atomic_bool baro_data_ready = false;
+/* Store pre-generated commands for sensor conversion
+ * Derived from config, set during init
+ */
+static uint8_t pressure_cmd;
+static uint8_t temperature_cmd;
 
+/* Store pre-calculated sensor conversion timeouts
+ * Derived from config, set during init, stored in microseconds
+ */
+static uint32_t pressure_timeout;
+static uint32_t temperature_timeout;
+
+/* Raw SPI bytes with readings */
+uint8_t baro_raw_temp_buffer[3];
+uint8_t baro_raw_press_buffer[3];
+
+/* State of barometer read process */
+static _Atomic BARO_READ_STATE baro_read_state = BARO_READ_FAIL;
+
+static BARO_STATUS success;
+
+/* Private function prototypes -----------------------------------------------*/
+
+/* Some of these are probably good candidates for macros */
+
+/*
+ * Implementation Notes
+ * I think we can create a TIM_OC_InitTypeDef, configure HAL_TIM_OC_ConfigChannel in a channel,
+ * and then run HAL_TIM_OC_Start. Our callback is then HAL_TIM_OC_DelayElapsedCallback().
+ */
+static BARO_STATUS create_timer_interrupt // TODO actually implement
+    (
+    uint32_t timeout_us
+    );
+
+static BARO_STATUS clear_timer_interrupt // TODO actually implement
+    (
+    void
+    );
+
+static BARO_STATUS transmit_cmd_IT
+    (
+    uint8_t command_byte
+    );
+
+static BARO_STATUS transceive_adc_IT
+    (
+    uint8_t* out_buffer
+    );
+
+static void update_state
+    (
+    BARO_READ_STATE next_state
+    );
+
+/* Procedures ----------------------------------------------------------------*/
+
+/* TODO
+ * - write baro_init and its helpers
+ * - write get_baro_it (this is where the buffers will be converted to
+ *   usable values and calculations applied to return the final float)
+ */
+
+/**
+  * @brief Check if barometer data is ready
+  *
+  * @details It looks at the barometer state machine status and checks if it
+  * is in a successful terminal state (BARO_READ_DONE, not BARO_READ_FAIL).
+  *
+  * @retval Ready status
+  */
+bool baro_get_baro_data_ready
+    (
+    void
+    )
+{
+return baro_read_state == BARO_READ_DONE;
+}
+
+/**
+  * @brief Initiate reading of baro via interrupt mode
+  *
+  * @details If baro_read_state is in a terminal state (OK or FAIL), this resets
+  * the state to the first state and calls the handler for the first time to
+  * start the process. If it is NOT in a terminal state, that means a read is already
+  * in progress, and this function will do nothing.
+  *
+  * @retval Status of the barometer
+  */
+BARO_STATUS start_baro_read_IT
+    (
+    void
+    )
+{
+switch(baro_read_state) {
+    case BARO_READ_FAIL:
+    case BARO_READ_DONE: // No currently running read
+        baro_read_state = BARO_CONV_PRESSURE;
+        baro_IT_handler(); // Keep FSM logic in that function
+        break;
+    default: // Read in progress
+        return BARO_BUSY;
+}
+}
+
+/**
+  * @brief Interrupt service routine for data acquisition
+  *
+  * @details This function must be called by three interrupt callbacks:
+  * SPI_TxCpltCallback(), HAL_SPI_TxRxCpltCallback(), and
+  * HAL_TIM_OC_DelayElapsedCallback(). These bring the read through a series of
+  * 7 states (plus a done and fail state), needed to account for timeouts required by the chip.
+  *
+  * @retval Status of the barometer
+  */
+BARO_STATUS baro_IT_handler
+    (
+    void
+    )
+{
+switch(baro_read_state) {
+    // TODO actually deal with chip select pin
+    case BARO_CONV_PRESSURE:
+        // 1. Called by start_baro_read_IT, start pressure conversion
+        success = transmit_cmd_IT(pressure_cmd);
+        update_state(BARO_WAIT_PRESSURE);
+        break;
+    case BARO_WAIT_PRESSURE:
+        // 2. Called by SPI_TxCpltCallback(), create pressure conversion timeout
+        success = create_timer_interrupt(pressure_timeout);
+        update_state(BARO_READ_PRESSURE);
+        break;
+    case BARO_READ_PRESSURE:
+        // 3. Called by HAL_TIM_OC_DelayElapsedCallback(), press temp ADC read
+        success = transceive_adc_IT(baro_raw_press_buffer);
+        update_state(BARO_CONV_TEMPERATURE);
+        break;
+    case BARO_CONV_TEMPERATURE:
+        // 4. Called by HAL_SPI_TxRxCpltCallback(), start temperature conversion
+        success = transmit_cmd_IT(temperature_cmd);
+        update_state(BARO_WAIT_TEMPERATURE);
+        break;
+    case BARO_WAIT_TEMPERATURE:
+        // 5. Called by SPI_TxCpltCallback(), create temp conversion timeout
+        success = create_timer_interrupt(temperature_timeout);
+        update_state(BARO_READ_TEMPERATURE);
+        break;
+    case BARO_READ_TEMPERATURE:
+        // 6. Called by HAL_TIM_OC_DelayElapsedCallback(), run temp ADC read
+        success = transceive_adc_IT(baro_raw_press_buffer);
+        update_state(BARO_READ_FINISH);
+        break;
+    case BARO_READ_FINISH:
+        // 7. Called by HAL_SPI_TxRxCpltCallback(), switch to done state.
+        success = BARO_OK;
+        update_state(BARO_READ_DONE);
+        break;
+    case BARO_READ_DONE:
+        // We're done. Nothing happens.
+        success = BARO_OK;
+        break;
+    default:
+        success = BARO_FAIL; // BARO_READ_FAIL or undefined state
+}
+return success;
+}
+
+/* Helpers ----------------------------------------------------------------*/
+
+/**
+ * @brief Transmits a single command byte to the baro
+ *
+ * @param command_byte The command byte to transmit.
+ *
+ * @retval The status of the barometer
+ */
+static BARO_STATUS transmit_cmd_IT
+    (
+    uint8_t command_byte
+    )
+{
+HAL_StatusTypeDef success;
+success = HAL_SPI_Transmit_IT(BARO_SPI, &command_byte, 1);
+
+if( success == HAL_OK ){
+    return BARO_OK;
+} else {
+    return BARO_SPI_ERROR;
+}
+}
+
+/**
+ * @brief Requests the 3 bytes of data currently in the ADC
+ *
+ * @param out_buffer The 3 byte buffer to place received SPI bytes in.
+ *
+ * @retval The status of the barometer
+ */
+static BARO_STATUS transceive_adc_IT
+    (
+    uint8_t* out_buffer
+    )
+{
+/* The zero byte is the ADC command, and the last two are filler bytes */
+/* They should do nothing in the chip's command language */
+/* This could still be wrong, though. We'll need to test on real HW. */
+/* Each result is 24 bits (3 bytes) */
+uint8_t in_buffer[3] = {0x00, 0xFF, 0xFF};
+
+HAL_StatusTypeDef success;
+success = HAL_SPI_TransmitReceive_IT(BARO_SPI, &in_buffer, &out_buffer, 3);
+
+if( success == HAL_OK ){
+    return BARO_OK;
+} else {
+    return BARO_SPI_ERROR;
+}
+}
+
+/**
+ * @brief Moved to requested state if no fail conditions are detected
+ *
+ * @param next_state The baro read state to switch to.
+ */
+static void update_state
+    (
+    BARO_READ_STATE next_state
+    )
+{
+if(success == BARO_OK)
+    {
+    baro_read_state = next_state;
+    }
+else
+    {
+    baro_read_state = BARO_READ_FAIL;
+    }
+}

--- a/baro/baro_r3.c
+++ b/baro/baro_r3.c
@@ -1,0 +1,58 @@
+/**
+  ******************************************************************************
+  * @file           : baro_r3.c
+  * @brief          : Driver for the barometer on FC rev 3.
+  ******************************************************************************
+  * @copyright
+  *
+  * Copyright (c) 2026 Sun Devil Rocketry.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is covered under the
+  * BSD-3-Clause.
+  *
+  * https://opensource.org/license/bsd-3-clause
+  */
+
+/*
+ * Implementation Notes
+ * I think we can create a TIM_OC_InitTypeDef, configure HAL_TIM_OC_ConfigChannel in a channel,
+ * and then run HAL_TIM_OC_Start. Our callback is then HAL_TIM_OC_DelayElapsedCallback().
+ */
+
+/* Includes ------------------------------------------------------------------*/
+
+/* Standard */
+#include <cstdint>
+#include <stdbool.h>
+#include <stdatomic.h>
+
+/* Project */
+#include "main.h"
+#include "stm32h7xx_hal.h"
+#include "sdr_pin_defines_A0010.h"
+#include "baro.h"
+
+/* Type Definitions ----------------------------------------------------------*/
+typedef struct _BARO_CAL_DATA_INT
+	{
+	uint16_t par_c1; // Pressure Sensitity
+	uint16_t par_c2; // Pressure Offset
+	uint16_t par_c3; // Temp. Coeff. of Pressure Sensitivity
+	uint16_t par_c4; // Temp. Coeff. of Pressure Offset
+	uint16_t par_c5; // Reference Temperature
+	uint16_t par_c6; // Temp. Coeff. of Temperature
+	} BARO_CAL_DATA_INT;
+
+/* Global Variables ----------------------------------------------------------*/
+
+/* Current Baro Sensor configuration */
+static BARO_CONFIG   baro_configuration;
+
+/* Baro calibration coefficients for measurement compensation */
+static BARO_CAL_DATA baro_cal_data;
+
+static atomic_bool baro_data_ready = false;
+

--- a/baro/baro_r3.c
+++ b/baro/baro_r3.c
@@ -121,7 +121,7 @@ static void update_state
 
 /* TODO
  * - write baro_init and its helpers
- * - write get_baro_it (this is where the buffers will be converted to
+ * - write baro_get_it (this is where the buffers will be converted to
  *   usable values and calculations applied to return the final float)
  * - write the timer interrupt creation functions
  */
@@ -152,7 +152,7 @@ return baro_read_state == BARO_READ_DONE;
   *
   * @retval Status of the barometer
   */
-BARO_STATUS start_baro_read_IT
+BARO_STATUS baro_start_read_IT
     (
     void
     )
@@ -189,7 +189,7 @@ BARO_STATUS baro_IT_handler
 switch(baro_read_state) {
     // TODO actually deal with chip select pin
     case BARO_CONV_PRESSURE:
-        // 1. Called by start_baro_read_IT, start pressure conversion
+        // 1. Called by baro_start_read_IT, start pressure conversion
         success = transmit_cmd_IT(pressure_cmd);
         update_state(BARO_WAIT_PRESSURE);
         break;

--- a/baro/baro_r3.c
+++ b/baro/baro_r3.c
@@ -121,7 +121,7 @@ static void update_state
 
 /* TODO
  * - write baro_init and its helpers
- * - write baro_get_it (this is where the buffers will be converted to
+ * - write baro_get_IT (this is where the buffers will be converted to
  *   usable values and calculations applied to return the final float)
  * - write the timer interrupt creation functions
  */

--- a/baro/baro_r3.c
+++ b/baro/baro_r3.c
@@ -157,15 +157,18 @@ BARO_STATUS start_baro_read_IT
     void
     )
 {
-switch(baro_read_state) {
+switch ( baro_read_state )
+    {
     case BARO_READ_FAIL:
+
     case BARO_READ_DONE: // No currently running read
         baro_read_state = BARO_CONV_PRESSURE;
         baro_IT_handler(); // Keep FSM logic in that function
         break;
+
     default: // Read in progress
         return BARO_BUSY;
-}
+    }
 }
 
 /**

--- a/baro/baro_r3.c
+++ b/baro/baro_r3.c
@@ -123,6 +123,7 @@ static void update_state
  * - write baro_init and its helpers
  * - write get_baro_it (this is where the buffers will be converted to
  *   usable values and calculations applied to return the final float)
+ * - write the timer interrupt creation functions
  */
 
 /**
@@ -196,6 +197,7 @@ switch(baro_read_state) {
         break;
     case BARO_READ_PRESSURE:
         // 3. Called by HAL_TIM_OC_DelayElapsedCallback(), press temp ADC read
+        clear_timer_interrupt();
         success = transceive_adc_IT(baro_raw_press_buffer);
         update_state(BARO_CONV_TEMPERATURE);
         break;
@@ -211,6 +213,7 @@ switch(baro_read_state) {
         break;
     case BARO_READ_TEMPERATURE:
         // 6. Called by HAL_TIM_OC_DelayElapsedCallback(), run temp ADC read
+        clear_timer_interrupt();
         success = transceive_adc_IT(baro_raw_press_buffer);
         update_state(BARO_READ_FINISH);
         break;
@@ -230,6 +233,32 @@ return success;
 }
 
 /* Helpers ----------------------------------------------------------------*/
+
+/**
+ * @brief Creates a timer interrupt for at least the specified duration
+ *
+ * @details This uses the microseconds timer, adding the requested time
+ * to the current time in microseconds modulo the period, to avoid corner
+ * cases with overflows
+ *
+ * @param timeout_us The time to wait in microseconds
+ *
+ * @retval The status of the barometer
+ */
+static BARO_STATUS create_timer_interrupt // TODO actually implement
+    (
+    uint32_t timeout_us
+    )
+{
+    // This uses output capture without changing pin
+    // PSEUDOCODE
+    // Create a TIM_OC_InitTypeDef
+    // Set its pulse to __HAL_TIM_GET_COUNTER(&MICRO_TIM) + timeout_us
+    // Set its mode to TIM_OCMODE_TIMING
+    // etc...
+    // Configure the given TIM channel with this.
+    // Start the timer. Handlers are called in stm32h7xx_it.c
+}
 
 /**
  * @brief Transmits a single command byte to the baro


### PR DESCRIPTION
## Description
Implements support for the MS5607-02BA03 barometer on the revision 3 Flight Computer. Not yet finished, currently a draft.

The way a read works in this implementation is it goes through a finite state machine to:
1. Initiate internal baro conversion for pressure.
2. Initiate the timeout required by the datasheet for pressure conversion.
3. Run the ADC read for pressure.
4. Initiate internal baro conversion for temperature.
5. Initiate the timeout required by the datasheet for temperature conversion.
6. Run the ADC read for temperature.
7. Move the FSM to the successful terminal state.

The getter function will then use the conversion factors to convert to useful float values (not yet implemented).

### Issue Link
#8
 
Also see corresponding firmware PR, SunDevilRocketry/Flight-Computer-Firmware#303, which has examples of the interrupt handlers that will be needed for this.

### Testing
- [ ] Passes existing unit tests
- [ ] Unit tests modified
- [ ] Integration test performed

Attach any test artifacts here, if relevant.

### Other
Leave any additional notes here

## Reviewer Checklist

### Standards
- [ ] Follows FCF Architectural Standards
- [ ] Follows SDR Coding Standards
- [ ] Code complexity/function Size is minimized
- [ ] Code is testable
- [ ] Code is readable and commented properly
- [ ] License terms are respected

### Error Handling
- [ ] Potentially unsafe functions return a status code
- [ ] Error returns properly handled

### Memory
- [ ] Stack allocated memory is scoped correctly
- [ ] Heap allocated memory is avoided
- [ ] Globally allocated memory is minimized except when necessary
- [ ] Pointers are used correctly
- [ ] Concurrency has been considered

### Performance
- [ ] Rate limiters are respected
- [ ] Busy waiting is avoided
- [ ] "Delay" calls are not used in performance sensitive code