### PR TITLE
Fix BMM150 blocking magnetometer read

### DIFF
--- a/imu/imu.c
+++ b/imu/imu.c
@@ -516,11 +516,12 @@ IMU_STATUS imu_get_mag_xyz
 /*------------------------------------------------------------------------------
  Local variables 
 ------------------------------------------------------------------------------*/
-uint8_t     regMag[6];    /* Magnetometer register bytes      */
-uint16_t    mag_x_raw;    /* Raw magnetometer sensor readouts */ 
-uint16_t    mag_y_raw; 
-uint16_t    mag_z_raw; 
-IMU_STATUS  imu_status;   /* IMU status return codes          */
+uint8_t    regMag[8];        /* Magnetometer register bytes      */
+int16_t    mag_x_raw;        /* Raw magnetometer sensor readouts */
+int16_t    mag_y_raw;
+int16_t    mag_z_raw;
+uint16_t   mag_hall_raw = 0; /* Rev 1 does not provide RHALL     */
+IMU_STATUS imu_status;       /* IMU status return codes           */
 
 
 /*------------------------------------------------------------------------------
@@ -528,40 +529,73 @@ IMU_STATUS  imu_status;   /* IMU status return codes          */
 ------------------------------------------------------------------------------*/
 
 /* Read MAG_X, MAG_Y, MAG_Z high byte and low byte registers */
-#if   defined( A0002_REV1 )
-    imu_status = read_mag_regs( IMU_REG_MAG_XOUT_H, 
-                                &regMag[0]        , 
-                                sizeof( regMag ) );
-#elif defined( A0002_REV2 )
-    imu_status = read_mag_regs( MAG_REG_DATAX_L, 
-                                &regMag[0]     , 
-                                sizeof( regMag ) );
+#if     defined(A0002_REV1)
+    imu_status = read_mag_regs(IMU_REG_MAG_XOUT_H,
+                               &regMag[0],
+                               6);
+#elif   defined(A0002_REV2)
+    imu_status = read_mag_regs(MAG_REG_DATAX_L,
+                               &regMag[0],
+                               sizeof(regMag));
 #endif
 
 /* Check for HAL IMU error */
-if ( imu_status == IMU_TIMEOUT )
-	{
-	return IMU_TIMEOUT;
-	}
+if ( imu_status != IMU_OK )
+    {
+    return imu_status;
+    }
 
 /* Combine high byte and low byte to 16 bit data */
 #if   defined( A0002_REV1 )
     mag_x_raw  = ( (uint16_t) regMag[1] ) << 8 | regMag[0];
     mag_y_raw  = ( (uint16_t) regMag[3] ) << 8 | regMag[2];
     mag_z_raw  = ( (uint16_t) regMag[5] ) << 8 | regMag[4];
-#elif defined( A0002_REV2 )
-    mag_x_raw  = (   (uint16_t) regMag[1]                         << MAG_XY_MSB_BITSHIFT ) | 
-                 ( ( (uint16_t) regMag[0] && MAG_XY_LSB_BITMASK ) >> MAG_XY_LSB_BITSHIFT );
-    mag_y_raw  = (   (uint16_t) regMag[3]                         << MAG_XY_MSB_BITSHIFT ) | 
-                 ( ( (uint16_t) regMag[2] && MAG_XY_LSB_BITMASK ) >> MAG_XY_LSB_BITSHIFT );
-    mag_z_raw  = (   (uint16_t) regMag[5]                         << MAG_Z_MSB_BITSHIFT  ) | 
-                 ( ( (uint16_t) regMag[4] && MAG_Z_LSB_BITMASK )  >> MAG_Z_LSB_BITSHIFT  );
+#elif defined(A0002_REV2)
+    mag_x_raw =
+        (int16_t)(((uint16_t)regMag[1] << MAG_XY_MSB_BITSHIFT) |
+        (((uint16_t)regMag[0] & MAG_XY_LSB_BITMASK) >>
+         MAG_XY_LSB_BITSHIFT));
+
+    mag_y_raw =
+        (int16_t)(((uint16_t)regMag[3] << MAG_XY_MSB_BITSHIFT) |
+        (((uint16_t)regMag[2] & MAG_XY_LSB_BITMASK) >>
+         MAG_XY_LSB_BITSHIFT));
+
+    mag_z_raw =
+        (int16_t)(((uint16_t)regMag[5] << MAG_Z_MSB_BITSHIFT) |
+        (((uint16_t)regMag[4] & MAG_Z_LSB_BITMASK) >>
+         MAG_Z_LSB_BITSHIFT));
+
+    mag_hall_raw =
+        (uint16_t)(((uint16_t)regMag[7] << MAG_RHALL_MSB_BITSHIFT) |
+        (((uint16_t)regMag[6] & MAG_RHALL_LSB_BITMASK) >>
+         MAG_RHALL_LSB_BITSHIFT));
+
+    /* Sign-extend the packed BMM150 measurements. */
+    if (mag_x_raw & (1 << 12))
+        {
+        mag_x_raw |= (int16_t)~((1 << 13) - 1);
+        }
+
+    if (mag_y_raw & (1 << 12))
+        {
+        mag_y_raw |= (int16_t)~((1 << 13) - 1);
+        }
+
+    if (mag_z_raw & (1 << 14))
+        {
+        mag_z_raw |= (int16_t)~((1 << 15) - 1);
+        }
 #endif
 
 /* Export sensor data */
 pIMU->mag_x = mag_x_raw;
 pIMU->mag_y = mag_y_raw;
 pIMU->mag_z = mag_z_raw;
+
+#if defined(A0002_REV2)
+pIMU->mag_hall = mag_hall_raw;
+#endif
 
 return IMU_OK;
 } /* imu_get_mag_xyz */

--- a/imu/imu.c
+++ b/imu/imu.c
@@ -504,8 +504,8 @@ return IMU_OK;
 * 		imu_get_mag_xyz                                                        *
 *                                                                              *
 * DESCRIPTION:                                                                 * 
-* 		Return the pointer to structure that updates the x,y,z magnetometer    *
-*       values from the IMU                                                    *
+*       Return the pointer to structure that updates the x, y, z, and RHALL    *
+*       magnetometer values from the BMM150.                                   *
 *                                                                              *
 *******************************************************************************/
 IMU_STATUS imu_get_mag_xyz
@@ -516,86 +516,63 @@ IMU_STATUS imu_get_mag_xyz
 /*------------------------------------------------------------------------------
  Local variables 
 ------------------------------------------------------------------------------*/
-uint8_t    regMag[8];        /* Magnetometer register bytes      */
-int16_t    mag_x_raw;        /* Raw magnetometer sensor readouts */
+uint8_t    regMag[8];      /* Magnetometer register bytes      */
+int16_t    mag_x_raw;      /* Raw magnetometer sensor readouts */
 int16_t    mag_y_raw;
 int16_t    mag_z_raw;
-uint16_t   mag_hall_raw = 0; /* Rev 1 does not provide RHALL     */
-IMU_STATUS imu_status;       /* IMU status return codes           */
+uint16_t   mag_hall_raw;
+IMU_STATUS imu_status;     /* IMU status return codes           */
 
 
 /*------------------------------------------------------------------------------
  API function implementation 
 ------------------------------------------------------------------------------*/
 
-/* Read MAG_X, MAG_Y, MAG_Z high byte and low byte registers */
-#if     defined(A0002_REV1)
-    imu_status = read_mag_regs(IMU_REG_MAG_XOUT_H,
-                               &regMag[0],
-                               6);
-#elif   defined(A0002_REV2)
-    imu_status = read_mag_regs(MAG_REG_DATAX_L,
-                               &regMag[0],
-                               sizeof(regMag));
-#endif
+/* Read BMM150 X, Y, Z, and RHALL registers */
+imu_status = read_mag_regs( MAG_REG_DATAX_L,
+                            &regMag[0],
+                            sizeof( regMag ) );
 
-/* Check for HAL IMU error */
+/* Check for magnetometer read error */
 if ( imu_status != IMU_OK )
     {
     return imu_status;
     }
 
-/* Combine high byte and low byte to 16 bit data */
-#if   defined( A0002_REV1 )
-    mag_x_raw  = ( (uint16_t) regMag[1] ) << 8 | regMag[0];
-    mag_y_raw  = ( (uint16_t) regMag[3] ) << 8 | regMag[2];
-    mag_z_raw  = ( (uint16_t) regMag[5] ) << 8 | regMag[4];
-#elif defined(A0002_REV2)
-    mag_x_raw =
-        (int16_t)(((uint16_t)regMag[1] << MAG_XY_MSB_BITSHIFT) |
-        (((uint16_t)regMag[0] & MAG_XY_LSB_BITMASK) >>
-         MAG_XY_LSB_BITSHIFT));
+/* Combine and scale the packed BMM150 register values */
+mag_x_raw = (int16_t)(   (uint16_t) regMag[1]                        << MAG_XY_MSB_BITSHIFT ) |
+                     ( ( (uint16_t) regMag[0] & MAG_XY_LSB_BITMASK ) >> MAG_XY_LSB_BITSHIFT );
 
-    mag_y_raw =
-        (int16_t)(((uint16_t)regMag[3] << MAG_XY_MSB_BITSHIFT) |
-        (((uint16_t)regMag[2] & MAG_XY_LSB_BITMASK) >>
-         MAG_XY_LSB_BITSHIFT));
+mag_y_raw = (int16_t)(   (uint16_t) regMag[3]                        << MAG_XY_MSB_BITSHIFT ) |
+                     ( ( (uint16_t) regMag[2] & MAG_XY_LSB_BITMASK ) >> MAG_XY_LSB_BITSHIFT );
 
-    mag_z_raw =
-        (int16_t)(((uint16_t)regMag[5] << MAG_Z_MSB_BITSHIFT) |
-        (((uint16_t)regMag[4] & MAG_Z_LSB_BITMASK) >>
-         MAG_Z_LSB_BITSHIFT));
+mag_z_raw = (int16_t)(   (uint16_t) regMag[5]                       << MAG_Z_MSB_BITSHIFT ) |
+                     ( ( (uint16_t) regMag[4] & MAG_Z_LSB_BITMASK ) >> MAG_Z_LSB_BITSHIFT );
 
-    mag_hall_raw =
-        (uint16_t)(((uint16_t)regMag[7] << MAG_RHALL_MSB_BITSHIFT) |
-        (((uint16_t)regMag[6] & MAG_RHALL_LSB_BITMASK) >>
-         MAG_RHALL_LSB_BITSHIFT));
+mag_hall_raw = (uint16_t)(   (uint16_t) regMag[7]                            << MAG_RHALL_MSB_BITSHIFT ) |
+                          ( ( (uint16_t) regMag[6] & MAG_RHALL_LSB_BITMASK ) >> MAG_RHALL_LSB_BITSHIFT );
 
-    /* Sign-extend the packed BMM150 measurements. */
-    if (mag_x_raw & (1 << 12))
-        {
-        mag_x_raw |= (int16_t)~((1 << 13) - 1);
-        }
+/* Sign-extend the packed 13-bit X/Y and 15-bit Z measurements */
+if ( mag_x_raw & ( 1 << 12 ) )
+    {
+    mag_x_raw |= (int16_t) ~( ( 1 << 13 ) - 1 );
+    }
 
-    if (mag_y_raw & (1 << 12))
-        {
-        mag_y_raw |= (int16_t)~((1 << 13) - 1);
-        }
+if ( mag_y_raw & ( 1 << 12 ) )
+    {
+    mag_y_raw |= (int16_t) ~( ( 1 << 13 ) - 1 );
+    }
 
-    if (mag_z_raw & (1 << 14))
-        {
-        mag_z_raw |= (int16_t)~((1 << 15) - 1);
-        }
-#endif
+if ( mag_z_raw & ( 1 << 14 ) )
+    {
+    mag_z_raw |= (int16_t) ~( ( 1 << 15 ) - 1 );
+    }
 
 /* Export sensor data */
-pIMU->mag_x = mag_x_raw;
-pIMU->mag_y = mag_y_raw;
-pIMU->mag_z = mag_z_raw;
-
-#if defined(A0002_REV2)
+pIMU->mag_x    = mag_x_raw;
+pIMU->mag_y    = mag_y_raw;
+pIMU->mag_z    = mag_z_raw;
 pIMU->mag_hall = mag_hall_raw;
-#endif
 
 return IMU_OK;
 } /* imu_get_mag_xyz */


### PR DESCRIPTION
## Description
Fixes the blocking BMM150 magnetometer read path so it is consistent with the interrupt-driven read path.

Changes:
- Read all 8 BMM150 data bytes on A0002 Rev 2, including RHALL
- Replace logical `&&` operations with bitwise `&` masks
- Sign-extend the packed 13-bit X/Y and 15-bit Z measurements
- Store the RHALL measurement in `IMU_RAW`
- Propagate all magnetometer read errors instead of checking only for timeout
- Preserve the six-byte read behavior for A0002 Rev 1


### Issue Link
Related to https://github.com/SunDevilRocketry/Flight-Computer-Firmware/issues/300


### Testing

- [x] Passes existing unit tests
- [x] Unit tests modified
- [x] Integration test performed

- `git diff --check` passed
- No existing host-side unit-test target compiles `driver/imu/imu.c`
- Hardware validation is still required

### Other

This PR fixes the blocking `imu_get_mag_xyz()` function, which is not currently called by the flight firmware, but served as a useful first step in familiarizing myself with the magnetometer implementation. Further work for issue #300 will investigate and validate the interrupt-driven magnetometer path used during normal operation and determine how the retrieved magnetometer data can be used for sensor fusion.

https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmm150-ds001.pdf

https://getyarn.io/yarn-clip/23a5374e-cb47-431e-82a0-7a63da68f11f/gif

## Reviewer Checklist

### Standards
- [x] Follows FCF Architectural Standards
- [x] Follows SDR Coding Standards
- [x] Code complexity/function Size is minimized
- [x] Code is testable
- [x] Code is readable and commented properly
- [x] License terms are respected

### Error Handling
- [x] Potentially unsafe functions return a status code
- [x] Error returns properly handled

### Memory
- [x] Stack allocated memory is scoped correctly
- [x] Heap allocated memory is avoided
- [x] Globally allocated memory is minimized except when necessary
- [x] Pointers are used correctly
- [x] Concurrency has been considered

### Performance
- [x] Rate limiters are respected
- [x] Busy waiting is avoided
- [x] "Delay" calls are not used in performance sensitive code